### PR TITLE
Fix: TypeError thrown from generateRandomClientId()

### DIFF
--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -1468,6 +1468,6 @@ class MQTTClient implements ClientContract
      */
     protected function generateRandomClientId(): string
     {
-        return substr(md5(uniqid(mt_rand(), true)), 0, 20);
+        return substr(md5(uniqid((string) mt_rand(), true)), 0, 20);
     }
 }


### PR DESCRIPTION
Creating an instance of `MQTTClient` without specifying the `clientId` argument was throwing a TypeError in `generateRandomClientId()` as `mt_rand()` returns an `int` but `uniqid()` expects `string`.