### PR TITLE
Make reads and writes to sockets silent with the @-operator

### DIFF
--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -1322,7 +1322,7 @@ class MQTTClient implements ClientContract
         $remaining   = $limit;
 
         if ($withoutBlocking) {
-            $receivedData = @fread($this->socket, $remaining);
+            $receivedData = fread($this->socket, $remaining);
             if ($receivedData === false) {
                 $this->logger->error('Reading data from the socket from an MQTT broker failed.', [
                     'broker' => sprintf('%s:%s', $this->host, $this->port),
@@ -1333,7 +1333,7 @@ class MQTTClient implements ClientContract
         }
 
         while (feof($this->socket) === false && $remaining > 0) {
-            $receivedData = @fread($this->socket, $remaining);
+            $receivedData = fread($this->socket, $remaining);
             if ($receivedData === false) {
                 $this->logger->error('Reading data from the socket from an MQTT broker failed.', [
                     'broker' => sprintf('%s:%s', $this->host, $this->port),

--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -1296,7 +1296,7 @@ class MQTTClient implements ClientContract
 
         $length = min($length, strlen($data));
 
-        $result = fwrite($this->socket, $data, $length);
+        $result = @fwrite($this->socket, $data, $length);
 
         if ($result === false || $result !== $length) {
             $this->logger->error('Sending data over the socket to an MQTT broker failed.', [
@@ -1322,7 +1322,7 @@ class MQTTClient implements ClientContract
         $remaining   = $limit;
 
         if ($withoutBlocking) {
-            $receivedData = fread($this->socket, $remaining);
+            $receivedData = @fread($this->socket, $remaining);
             if ($receivedData === false) {
                 $this->logger->error('Reading data from the socket from an MQTT broker failed.', [
                     'broker' => sprintf('%s:%s', $this->host, $this->port),
@@ -1333,7 +1333,7 @@ class MQTTClient implements ClientContract
         }
 
         while (feof($this->socket) === false && $remaining > 0) {
-            $receivedData = fread($this->socket, $remaining);
+            $receivedData = @fread($this->socket, $remaining);
             if ($receivedData === false) {
                 $this->logger->error('Reading data from the socket from an MQTT broker failed.', [
                     'broker' => sprintf('%s:%s', $this->host, $this->port),


### PR DESCRIPTION
If the MQTT daemon closes the connection before `MQTTClient` sends a keepalive ping the socket ends up broken and PHP issues a notice. Some frameworks halts the execution on all errors which makes it impossible to catch the `DataTransferException`  and reconnect.

This commit makes all `fread` and `fwrite` completely silent and hands over to the already built in error handling in `MQTTClient`.