### PR TITLE
Reset the last ping time only after a ping is sent, rather than after…

### DIFF
--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -244,7 +244,6 @@ class MQTTClient implements ClientContract
                 switch ($acknowledgement[3]) {
                     case chr(0):
                         $this->logger->info(sprintf('Connection with MQTT broker at [%s:%s] established successfully.', $this->host, $this->port));
-                        $this->lastPingAt = microtime(true);
                         break;
                     case chr(1):
                         $this->logger->error(sprintf('The MQTT broker at [%s:%s] does not support MQTT v3.', $this->host, $this->port));
@@ -347,7 +346,6 @@ class MQTTClient implements ClientContract
         ]);
 
         $this->writeToSocket(chr(0xc0) . chr(0x00));
-        $this->lastPingAt = microtime(true);
     }
 
     /**
@@ -1303,6 +1301,10 @@ class MQTTClient implements ClientContract
             ]);
             throw new DataTransferException(self::EXCEPTION_TX_DATA, 'Sending data over the socket failed. Has it been closed?');
         }
+        
+        // After writing successfully to the socket, the broker should have received a new message from us.
+        // Because we only need to send a ping if no other messages are delivered, we can safely reset the ping timer.
+        $this->lastPingAt = microtime(true);
     }
 
     /**

--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -347,6 +347,7 @@ class MQTTClient implements ClientContract
         ]);
 
         $this->writeToSocket(chr(0xc0) . chr(0x00));
+        $this->lastPingAt = microtime(true);
     }
 
     /**
@@ -653,8 +654,6 @@ class MQTTClient implements ClientContract
                             $this->logger->debug(sprintf('Received message with unsupported command [%s]. Skipping.', $command));
                             break;
                     }
-
-                    $this->lastPingAt = microtime(true);
                 } else {
                     $this->logger->error('A reserved command has been received from an MQTT broker. Supported are commands (including) 1-14.', [
                         'broker' => sprintf('%s:%s', $this->host, $this->port),


### PR DESCRIPTION
Using php-mqtt v0.1.2 as a subscriber, and mosquitto v1.4.15 as the broker:

Whenever the client receives a command from the broker, it resets its internal "last ping" time. If these commands are received frequently enough, the "last ping" time never exceeds the keepalive value, so pings are never sent, causing the broker to report the client has timed out and close the connection. I get a message like this in the mosquitto log:

    Client myclientid has exceeded timeout, disconnecting.

And the client throws an exception soon after:

    PHP Fatal error:  Uncaught PhpMqtt\Client\Exceptions\DataTransferException: [65] Transfering data over socket failed: Sending data over the socket failed. Has it been closed? in /home/brad/temp/job_processor_mqtt/vendor/php-mqtt/client/src/MQTTClient.php:1308

Not having read the MQTT spec, I don't know if this is a bug in the client or the broker. I was able to fix it by only resetting the last ping time after a ping is sent, rather than after every broker command is received. 