### PR TITLE
Fix: use addition to increase message size

### DIFF
--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -223,12 +223,12 @@ class MQTTClient implements ClientContract
             if ($username !== null) {
                 $usernamePart = $this->buildLengthPrefixedString($username);
                 $buffer      .= $usernamePart;
-                $i           .= strlen($usernamePart);
+                $i           += strlen($usernamePart);
             }
             if ($password !== null) {
                 $passwordPart = $this->buildLengthPrefixedString($password);
                 $buffer      .= $passwordPart;
-                $i           .= strlen($passwordPart);
+                $i           += strlen($passwordPart);
             }
 
             // message type and message length


### PR DESCRIPTION
When using a username and password to connect to a broker, the message size has been manipulated using string concatenation instead of mathematical addition. This caused an issue with `chr()` expecting an integer and not a string. It also would have lead to wrong information being sent.