### PR TITLE
Added possibility to retrieve the raw socket and loop externally

### DIFF
--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -57,9 +57,6 @@ class MQTTClient implements ClientContract
     /** @var string|null */
     private $caFile;
 
-    /** @var resource|null */
-    private $socket;
-
     /** @var float */
     private $lastPingAt;
 
@@ -74,6 +71,9 @@ class MQTTClient implements ClientContract
 
     /** @var bool */
     private $interrupted = false;
+
+    /** @var resource|null */
+    protected $socket;
 
     /**
      * Constructs a new MQTT client which subsequently supports publishing and subscribing.


### PR DESCRIPTION
When multiplexing between different streams there is the need to use stream_select() on the raw sockets, and then run for a single time into the main loop of the library. These two changes allow to do so.