### PR TITLE
dependabot: only suggest updates of dev packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ version: 2
 updates:
   - package-ecosystem: "composer"
     directory: "/"
+    allow:
+      - dependency-type: "development"
     schedule:
       interval: "daily"
       time: "05:00"


### PR DESCRIPTION
Since we purposefully use lower versions of dependencies, it makes sense to suggest only development updates.