### PR TITLE
Added 'retained' parameter to subscriptions callbacks for published messages

### DIFF
--- a/src/Contracts/MQTTClient.php
+++ b/src/Contracts/MQTTClient.php
@@ -51,6 +51,24 @@ interface MQTTClient
     /**
      * Subscribe to the given topic with the given quality of service.
      *
+     * The subscription callback is passed the topic as first and the message as second
+     * parameter. A third parameter indicates whether the received message has been sent
+     * because it was retained by the broker.
+     *
+     * Example:
+     * ```php
+     * $mqtt->subscribe(
+     *     '/foo/bar/+',
+     *     function (string $topic, string $message, bool $retained) use ($logger) {
+     *         $logger->info("Received {retained} message on topic [{topic}]: {message}", [
+     *             'topic' => $topic,
+     *             'message' => $message,
+     *             'retained' => $retained ? 'retained' : 'live'
+     *         ]);
+     *     }
+     * );
+     * ```
+     *
      * @param string   $topic
      * @param callable $callback
      * @param int      $qualityOfService

--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -113,10 +113,10 @@ class MQTTClient implements ClientContract
      * If no custom settings are passed, the client will use the default settings.
      * See {@see ConnectionSettings} for more details about the defaults.
      *
-     * @param string|null        $username
-     * @param string|null        $password
-     * @param ConnectionSettings $settings
-     * @param bool               $sendCleanSessionFlag
+     * @param string|null             $username
+     * @param string|null             $password
+     * @param ConnectionSettings|null $settings
+     * @param bool                    $sendCleanSessionFlag
      * @return void
      * @throws ConnectingToBrokerFailedException
      */
@@ -724,10 +724,11 @@ class MQTTClient implements ClientContract
      *
      * @param string $buffer
      * @param int    $qualityOfServiceLevel
+     * @param bool   $retained
      * @return void
      * @throws DataTransferException
      */
-    protected function handlePublishedMessage(string $buffer, int $qualityOfServiceLevel, bool $retained = null): void
+    protected function handlePublishedMessage(string $buffer, int $qualityOfServiceLevel, bool $retained = false): void
     {
         $topicLength = (ord($buffer[0]) << 8) + ord($buffer[1]);
         $topic       = substr($buffer, 2, $topicLength);
@@ -1063,9 +1064,10 @@ class MQTTClient implements ClientContract
      * @param string $topic
      * @param string $message
      * @param int    $qualityOfServiceLevel
+     * @param bool   $retained
      * @return void
      */
-    protected function deliverPublishedMessage(string $topic, string $message, int $qualityOfServiceLevel, bool $retained = null): void
+    protected function deliverPublishedMessage(string $topic, string $message, int $qualityOfServiceLevel, bool $retained = false): void
     {
         $subscribers = $this->repository->getTopicSubscriptionsMatchingTopic($topic);
 

--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -403,7 +403,7 @@ class MQTTClient implements ClientContract
 
     /**
      * Builds and publishes a message.
-     * 
+     *
      * @param string   $topic
      * @param string   $message
      * @param int      $qualityOfService
@@ -469,6 +469,24 @@ class MQTTClient implements ClientContract
 
     /**
      * Subscribe to the given topic with the given quality of service.
+     *
+     * The subscription callback is passed the topic as first and the message as second
+     * parameter. A third parameter indicates whether the received message has been sent
+     * because it was retained by the broker.
+     *
+     * Example:
+     * ```php
+     * $mqtt->subscribe(
+     *     '/foo/bar/+',
+     *     function (string $topic, string $message, bool $retained) use ($logger) {
+     *         $logger->info("Received {retained} message on topic [{topic}]: {message}", [
+     *             'topic' => $topic,
+     *             'message' => $message,
+     *             'retained' => $retained ? 'retained' : 'live'
+     *         ]);
+     *     }
+     * );
+     * ```
      *
      * @param string   $topic
      * @param callable $callback
@@ -771,9 +789,9 @@ class MQTTClient implements ClientContract
     /**
      * Handles a received publish acknowledgement. The buffer contains the whole
      * message except command and length. The message structure is:
-     * 
+     *
      *   [message-identifier]
-     * 
+     *
      * @param string $buffer
      * @return void
      * @throws UnexpectedAcknowledgementException
@@ -991,9 +1009,9 @@ class MQTTClient implements ClientContract
     /**
      * Handles a received unsubscribe acknowledgement. The buffer contains the whole
      * message except command and length. The message structure is:
-     * 
+     *
      *   [message-identifier]
-     * 
+     *
      * @param string $buffer
      * @return void
      * @throws UnexpectedAcknowledgementException
@@ -1304,7 +1322,7 @@ class MQTTClient implements ClientContract
             ]);
             throw new DataTransferException(self::EXCEPTION_TX_DATA, 'Sending data over the socket failed. Has it been closed?');
         }
-        
+
         // After writing successfully to the socket, the broker should have received a new message from us.
         // Because we only need to send a ping if no other messages are delivered, we can safely reset the ping timer.
         $this->lastPingAt = microtime(true);


### PR DESCRIPTION
If the publisher set the retained flag the broker will honor it and send the published messages to the subscriber as soon as he subscribes, but the subscribe callback might need to know whether the message was delivered live or if it was retained, which could mean the message is stale.
