### PR TITLE
Improved connection error handling and TLS options

### DIFF
--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -35,6 +35,15 @@ class ConnectionSettings
     /** @var string */
     private $lastWillMessage;
 
+    /** @var bool */
+    private $useTls;
+
+    /** @var bool */
+    private $tlsVerifyPeer;
+
+    /** @var bool */
+    private $tlsVerifyName;
+
     /**
      * Constructs a new settings object.
      *
@@ -46,6 +55,9 @@ class ConnectionSettings
      * @param int         $resendTimeout
      * @param string|null $lastWillTopic
      * @param string|null $lastWillMessage
+     * @param bool        $useTls
+     * @param bool        $tlsVerifyPeer
+     * @param bool        $tlsVerifyName
      */
     public function __construct(
         int $qualityOfService = 0,
@@ -55,7 +67,10 @@ class ConnectionSettings
         int $keepAlive = 10,
         int $resendTimeout = 10,
         string $lastWillTopic = null,
-        string $lastWillMessage = null
+        string $lastWillMessage = null,
+        bool $useTls = false,
+        bool $tlsVerifyPeer = true,
+        bool $tlsVerifyName = true
     )
     {
         $this->qualityOfService = $qualityOfService;
@@ -66,6 +81,9 @@ class ConnectionSettings
         $this->resendTimeout    = $resendTimeout;
         $this->lastWillTopic    = $lastWillTopic;
         $this->lastWillMessage  = $lastWillMessage;
+        $this->useTls           = $useTls;
+        $this->tlsVerifyPeer    = $tlsVerifyPeer;
+        $this->tlsVerifyName    = $tlsVerifyName;
     }
 
     /**
@@ -168,5 +186,35 @@ class ConnectionSettings
     public function hasLastWill(): bool
     {
         return $this->lastWillTopic !== null && $this->lastWillMessage !== null;
+    }
+
+    /**
+     * Determines whether the client wants to use TLS.
+     *
+     * @return bool
+     */
+    public function shouldUseTls(): bool
+    {
+        return $this->useTls;
+    }
+
+    /**
+     * Determines whether the TLS peer certificate validation must occur.
+     *
+     * @return bool
+     */
+    public function shouldTlsVerifyPeer(): bool
+    {
+        return $this->tlsVerifyPeer;
+    }
+
+    /**
+     * Determines whether we should check for name match of the certificate.
+     *
+     * @return bool
+     */
+    public function shouldTlsVerifyPeerName(): bool
+    {
+        return $this->tlsVerifyName;
     }
 }

--- a/src/Exceptions/ConnectingToBrokerFailedException.php
+++ b/src/Exceptions/ConnectingToBrokerFailedException.php
@@ -11,11 +11,39 @@ namespace PhpMqtt\Client\Exceptions;
  */
 class ConnectingToBrokerFailedException extends MQTTClientException
 {
-    public function __construct(int $code, string $error)
+    /** @var string|null */
+    private $connectionErrorMessage;
+
+    /** @var string|null */
+    private $connectionErrorCode;
+
+    public function __construct(int $code, string $error, string $innerMessage = null, string $innerCode = null)
     {
         parent::__construct(
             sprintf('[%s] Establishing a connection to the MQTT broker failed: %s', $code, $error),
             $code
         );
+        $this->connectionErrorMessage = $innerMessage;
+        $this->connectionErrorCode    = $innerCode;
+    }
+
+    /**
+     * Retrieves the connection error message.
+     *
+     * @return string|null
+     */
+    public function getConnectionErrorMessage(): ?string
+    {
+        return $this->connectionErrorMessage;
+    }
+
+    /**
+     * Retrieves the connection error code.
+     *
+     * @return string|null
+     */
+    public function getConnectionErrorCode(): ?string
+    {
+        return $this->connectionErrorCode;
     }
 }

--- a/src/Exceptions/ConnectingToBrokerFailedException.php
+++ b/src/Exceptions/ConnectingToBrokerFailedException.php
@@ -17,13 +17,21 @@ class ConnectingToBrokerFailedException extends MQTTClientException
     /** @var string|null */
     private $connectionErrorCode;
 
+    /**
+     * ConnectingToBrokerFailedException constructor.
+     *
+     * @param int         $code
+     * @param string      $error
+     * @param string|null $innerMessage
+     * @param string|null $innerCode
+     */
     public function __construct(int $code, string $error, string $innerMessage = null, string $innerCode = null)
     {
         parent::__construct(
             sprintf('[%s] Establishing a connection to the MQTT broker failed: %s', $code, $error),
             $code
         );
-        $this->connectionErrorMessage = $innerMessage;
+        $this->connectionErrorMessage = ($innerMessage ?? $error);
         $this->connectionErrorCode    = $innerCode;
     }
 


### PR DESCRIPTION
# Introduction

This change addresses several issues with the handling of failed connections, distinguishing three different *tiers* depending on the type of issue, which I try to outline below.

All errors are represented by the `ConnectingToBrokerFailedException`

For tier-specific error information, you can get message and code using the two additional methods in the exception. The user that is interesting in understanding more about the error can map and inspect these codes using external means.

## Tier 1 - TCP socket issues
* Represented by the `EXCEPTION_CONNECTION_SOCKET_ERROR` error code.
* Error message contains the raw sockets error message, code contains the POSIX socket error number (see  for a full list).
* Some examples are:
  * Network is unreachable (ENETUNREACH - 101)
  * Connection refused (ECONNREFUSED - 110)
  * No route to host (EHOSTUNREACH - 112)
* There are [plenty more POSIX errors](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/asm-generic/errno.h) defined for TCP connections.

## Tier 1.5 - TLS issues
* Represented by the EXCEPTION_CONNECTION_TLS_ERROR` error code.
* Unfortunately, the OpenSSL library itself and the PHP implementation of it handle this quite badly, so the actual error message and code is extracted by a string, so not always available.
* Some examples are:
  * `SSL: Handshake timed out` (no code available)
  * `SSL operation failed with code 1. OpenSSL Error messages:\nerror:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed` (code `1416F086`)
  * `Peer certificate CN='localhost' did not match expected CN='127.0.0.1'` (no code available)
* These might different depending on the actual OpenSSL library version

## Tier 2.0 - Protocol issues
* Represented by `EXCEPTION_CONNECTION_FAILED`
* Once the connection has been fully established (with or without TLS at this point no longer matters), we have to deal with protocol issues. As we send out the CONNECT packet three things can go wrong:
  1. Server never replies (client should give up waiting at some point, socketTimeout?)
  2. Server closes the connection without saying anything (this actually happens in many situations)
  3. Server sends garbage (protocol violation, we should immediately close)
* Otherwise, the server sends a valid CONNACK containing refuse reason (either itself valid or not, see Tier 2.5)
* Note that cases 1-3 we consider as the same error, we do not distuinguish.

## Tier 2.5 - Connection rejected
* Represented by their respective error codes, plus `EXCEPTION_CONNECTION_UNKNOWN_ERROR` for unknown rejection codes.
  * EXCEPTION_CONNECTION_PROTOCOL_VERSION
  * EXCEPTION_CONNECTION_IDENTIFIER_REJECTED
  * EXCEPTION_CONNECTION_BROKER_UNAVAILABLE
  * (and so on for the remaining exception codes)


# List of actual changes

* Added protected method `MQTTClient::closeSocket()`
* Added methods `getConnectionErrorMessage()` and `getConnectionErrorCode()` to `ConnectingToBrokerFailedException` to obtain the inner error message and code when available. The actual exception message is left as is to be more descriptive at the higher level.
* Added MQTT v3.1 replies `EXCEPTION_CONNECTION_BAD_LOGIN` (MQTT code 4) and `EXCEPTION_CONNECTION_NOT_AUTHORIZED` (MQTT code 5).
* Connecting again using `connect()` now causes the previous socket to be abruptly closed
* Added `useTls`, `tlsVerifyPeer` and `tlsVerifyName` to `ConnectionSettings`.
* Honour the `socketTimeout` setting for opening the socket connection as well.


# Future development

For the refactory branch, I would recomment to renumber the exception constants to match their assigned tier group.
