### PR TITLE
A a workflow to run unit and feature tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit:8.5
+          tools: phpunit:8.5.8
           coverage: pcov
 
       - name: Setup problem matchers for PHP

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: php-actions/composer@v1
 
-      - uses: php-actions/phpunit@v1
+      - uses: php-actions/phpunit@master
         with:
           config: phpunit.xml
           memory: 128M
@@ -51,7 +51,7 @@ jobs:
 
       - uses: php-actions/composer@v1
 
-      - uses: php-actions/phpunit@v1
+      - uses: php-actions/phpunit@master
         with:
           config: phpunit.xml
           memory: 128M

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,11 +3,27 @@ name: Tests
 on: [push]
 
 jobs:
-  test-unit:
-    name: Unit
-    runs-on: ubuntu-latest
+  test-all:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+          php-versions: ['7.2', '7.3', '7.4']
+    name: PHP ${{ matrix.php-versions }} tests on ${{ matrix.operating-system }}
     steps:
       - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: phpunit
+          coverage: pcov
+
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -19,40 +35,10 @@ jobs:
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
+          restore-keys: ${{ runner.os }}-composer-
 
-      - uses: php-actions/composer@v1
+      - name: Install composer dependencies
+        run: composer install --prefer-dist
 
-      - uses: php-actions/phpunit@master
-        with:
-          config: phpunit.xml
-          memory: 128M
-          testsuite: Unit
-
-  test-feature:
-    name: Feature
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - uses: php-actions/composer@v1
-
-      - uses: php-actions/phpunit@master
-        with:
-          config: phpunit.xml
-          memory: 128M
-          testsuite: Feature
+      - name: Run phpunit tests
+        run: phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,10 @@
-name: Unit & Feature Tests
+name: Tests
 
 on: [push]
 
 jobs:
   test-unit:
+    name: Unit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -30,6 +31,7 @@ jobs:
           testsuite: Unit
 
   test-feature:
+    name: Feature
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit
+          tools: phpunit:8.5
           coverage: pcov
 
       - name: Setup problem matchers for PHP

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,56 @@
+name: Unit & Feature Tests
+
+on: [push]
+
+jobs:
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - uses: php-actions/composer@v1
+
+      - uses: php-actions/phpunit@v1
+        with:
+          config: phpunit.xml
+          memory: 128M
+          testsuite: Unit
+
+  test-feature:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - uses: php-actions/composer@v1
+
+      - uses: php-actions/phpunit@v1
+        with:
+          config: phpunit.xml
+          memory: 128M
+          testsuite: Feature

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-          php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4']
     name: PHP ${{ matrix.php-versions }} tests on ${{ matrix.operating-system }}
     steps:
       - uses: actions/checkout@v2

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
This PR adds a new `tests.yml` which runs unit and feature tests with `phpunit` using a matrix strategy on the following operating systems and PHP versions:
- Operating systems: `ubuntu-latest`, `windows-latest` and `macos-latest`
- PHP versions: `7.2`, `7.3` and `7.4`