### PR TITLE
Inline 'addNew[...]' methods to MqttClient to reduce Repository interface

### DIFF
--- a/src/Contracts/Repository.php
+++ b/src/Contracts/Repository.php
@@ -59,17 +59,6 @@ interface Repository
     public function addTopicSubscription(TopicSubscription $subscription): void;
 
     /**
-     * Adds a new topic subscription with the given settings to the repository.
-     *
-     * @param string   $topic
-     * @param callable $callback
-     * @param int      $messageId
-     * @param int      $qualityOfService
-     * @return TopicSubscription
-     */
-    public function addNewTopicSubscription(string $topic, callable $callback, int $messageId, int $qualityOfService): TopicSubscription;
-
-    /**
      * Get all topic subscriptions with the given message identifier.
      *
      * @param int $messageId
@@ -117,26 +106,6 @@ interface Repository
      * @return void
      */
     public function addPendingPublishedMessage(PublishedMessage $message): void;
-
-    /**
-     * Adds a new pending published message with the given settings to the repository.
-     *
-     * @param int           $messageId
-     * @param string        $topic
-     * @param string        $message
-     * @param int           $qualityOfService
-     * @param bool          $retain
-     * @param DateTime|null $sentAt
-     * @return PublishedMessage
-     */
-    public function addNewPendingPublishedMessage(
-        int $messageId,
-        string $topic,
-        string $message,
-        int $qualityOfService,
-        bool $retain,
-        DateTime $sentAt = null
-    ): PublishedMessage;
 
     /**
      * Gets a pending published message with the given message identifier, if found.
@@ -190,16 +159,6 @@ interface Repository
     public function addPendingUnsubscribeRequest(UnsubscribeRequest $request): void;
 
     /**
-     * Adds a new pending unsubscribe request with the given settings to the repository.
-     *
-     * @param int           $messageId
-     * @param string        $topic
-     * @param DateTime|null $sentAt
-     * @return UnsubscribeRequest
-     */
-    public function addNewPendingUnsubscribeRequest(int $messageId, string $topic, DateTime $sentAt = null): UnsubscribeRequest;
-
-    /**
      * Gets a pending unsubscribe request with the given message identifier, if found.
      *
      * @param int $messageId
@@ -240,17 +199,6 @@ interface Repository
      * @throws PendingPublishConfirmationAlreadyExistsException
      */
     public function addPendingPublishConfirmation(PublishedMessage $message): void;
-
-    /**
-     * Adds a new pending publish confirmation with the given settings to the repository.
-     *
-     * @param int    $messageId
-     * @param string $topic
-     * @param string $message
-     * @return PublishedMessage
-     * @throws PendingPublishConfirmationAlreadyExistsException
-     */
-    public function addNewPendingPublishConfirmation(int $messageId, string $topic, string $message): PublishedMessage;
 
     /**
      * Gets a pending publish confirmation with the given message identifier, if found.

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -537,7 +537,9 @@ class MqttClient implements ClientContract
 
         if ($qualityOfService > self::QOS_AT_MOST_ONCE) {
             $messageId = $this->repository->newMessageId();
-            $this->repository->addNewPendingPublishedMessage($messageId, $topic, $message, $qualityOfService, $retain);
+
+            $pendingMessage = new PublishedMessage($messageId, $topic, $message, $qualityOfService, $retain);
+            $this->repository->addPendingPublishedMessage($pendingMessage);
         }
 
         $this->publishMessage($topic, $message, $qualityOfService, $retain, $messageId);
@@ -629,7 +631,8 @@ class MqttClient implements ClientContract
             'qos' => $qualityOfService,
         ]);
 
-        $this->repository->addNewTopicSubscription($topic, $callback, $messageId, $qualityOfService);
+        $pendingMessage = new TopicSubscription($topic, $callback, $messageId, $qualityOfService);
+        $this->repository->addTopicSubscription($pendingMessage);
 
         $this->writeToSocket($data);
     }
@@ -659,7 +662,8 @@ class MqttClient implements ClientContract
             'topic' => $topic,
         ]);
 
-        $this->repository->addNewPendingUnsubscribeRequest($messageId, $topic);
+        $pendingMessage = new UnsubscribeRequest($messageId, $topic);
+        $this->repository->addPendingUnsubscribeRequest($pendingMessage);
 
         $this->writeToSocket($data);
     }
@@ -817,11 +821,14 @@ class MqttClient implements ClientContract
             if ($message->getQualityOfService() === self::QOS_EXACTLY_ONCE) {
                 try {
                     $this->sendPublishReceived($message->getMessageId());
-                    $this->repository->addNewPendingPublishConfirmation(
+                    $pendingMessage = new PublishedMessage(
                         $message->getMessageId(),
                         $message->getTopic(),
-                        $message->getContent()
+                        $message->getContent(),
+                        2,
+                        false
                     );
+                    $this->repository->addPendingPublishConfirmation($pendingMessage);
                 } catch (PendingPublishConfirmationAlreadyExistsException $e) {
                     // We already received and processed this message, therefore we do not respond
                     // with a receipt a second time and wait for the release instead.

--- a/src/Repositories/BaseRepository.php
+++ b/src/Repositories/BaseRepository.php
@@ -26,57 +26,12 @@ abstract class BaseRepository
     abstract public function addTopicSubscription(TopicSubscription $subscription): void;
 
     /**
-     * Adds a topic subscription to the repository.
-     *
-     * @param string   $topic
-     * @param callable $callback
-     * @param int      $messageId
-     * @param int      $qualityOfService
-     * @return TopicSubscription
-     */
-    public function addNewTopicSubscription(string $topic, callable $callback, int $messageId, int $qualityOfService): TopicSubscription
-    {
-        $subscription = new TopicSubscription($topic, $callback, $messageId, $qualityOfService);
-
-        $this->addTopicSubscription($subscription);
-
-        return $subscription;
-    }
-
-    /**
      * Adds a pending published message to the repository.
      *
      * @param PublishedMessage $message
      * @return void
      */
     abstract public function addPendingPublishedMessage(PublishedMessage $message): void;
-
-    /**
-     * Adds a new pending published message with the given settings to the repository.
-     *
-     * @param int           $messageId
-     * @param string        $topic
-     * @param string        $message
-     * @param int           $qualityOfService
-     * @param bool          $retain
-     * @param DateTime|null $sentAt
-     * @return PublishedMessage
-     */
-    public function addNewPendingPublishedMessage(
-        int $messageId,
-        string $topic,
-        string $message,
-        int $qualityOfService,
-        bool $retain,
-        DateTime $sentAt = null
-    ): PublishedMessage
-    {
-        $message = new PublishedMessage($messageId, $topic, $message, $qualityOfService, $retain, $sentAt);
-
-        $this->addPendingPublishedMessage($message);
-
-        return $message;
-    }
 
     /**
      * Adds a pending unsubscribe request to the repository.
@@ -87,23 +42,6 @@ abstract class BaseRepository
     abstract public function addPendingUnsubscribeRequest(UnsubscribeRequest $request): void;
 
     /**
-     * Adds a new pending unsubscribe request with the given settings to the repository.
-     *
-     * @param int           $messageId
-     * @param string        $topic
-     * @param DateTime|null $sentAt
-     * @return UnsubscribeRequest
-     */
-    public function addNewPendingUnsubscribeRequest(int $messageId, string $topic, DateTime $sentAt = null): UnsubscribeRequest
-    {
-        $request = new UnsubscribeRequest($messageId, $topic, $sentAt);
-
-        $this->addPendingUnsubscribeRequest($request);
-
-        return $request;
-    }
-
-    /**
      * Adds a pending publish confirmation to the repository.
      *
      * @param PublishedMessage $message
@@ -111,22 +49,4 @@ abstract class BaseRepository
      * @throws PendingPublishConfirmationAlreadyExistsException
      */
     abstract public function addPendingPublishConfirmation(PublishedMessage $message): void;
-
-    /**
-     * Adds a new pending publish confirmation with the given settings to the repository.
-     *
-     * @param int    $messageId
-     * @param string $topic
-     * @param string $message
-     * @return PublishedMessage
-     * @throws PendingPublishConfirmationAlreadyExistsException
-     */
-    public function addNewPendingPublishConfirmation(int $messageId, string $topic, string $message): PublishedMessage
-    {
-        $message = new PublishedMessage($messageId, $topic, $message, 2, false);
-
-        $this->addPendingPublishConfirmation($message);
-
-        return $message;
-    }
 }


### PR DESCRIPTION
The methods `addNewTopicSubscription()`, `addNewPendingPublishedMessage()`, and `addNewPendingPublishConfirmation()` are invoked only once in the MqttClient class and can be inlined to reduce the Repository interface.
