### PR TITLE
Fix: Send PUBREL in response to PUBREC

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -3,6 +3,9 @@
     <description>php-mqtt Code Style Standard</description>
 
     <rule ref="PSR1"/>
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
     <rule ref="PSR2">
         <exclude name="PSR2.Methods.MethodDeclaration.AbstractAfterVisibility"/>
         <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis"/>

--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -991,6 +991,8 @@ class MQTTClient implements ClientContract
                 'The MQTT broker sent a receipt for a publish that has not been pending anymore.'
             );
         }
+
+        $this->sendPublishRelease($messageId);
     }
 
     /**
@@ -1270,6 +1272,23 @@ class MQTTClient implements ClientContract
         ]);
 
         $this->writeToSocket(chr(0x50) . chr(0x02) . $this->encodeMessageId($messageId));
+    }
+
+    /**
+     * Sends a publish release message for the given message identifier.
+     *
+     * @param int $messageId
+     * @return void
+     * @throws DataTransferException
+     */
+    protected function sendPublishRelease(int $messageId): void
+    {
+        $this->logger->debug('Sending publish release message to an MQTT broker.', [
+            'broker' => sprintf('%s:%s', $this->host, $this->port),
+            'message_id' => $messageId,
+        ]);
+
+        $this->writeToSocket(chr(0x62) . chr(0x02) . $this->encodeMessageId($messageId));
     }
 
     /**


### PR DESCRIPTION
Currently, the QoS 2 message flow is broken when the MQTT client is used to subscribe to topics with QoS 2 where messages are received with QoS 2. No `PUBREL` message is sent in response to a received `PUBREC` message.