### PR TITLE
Add support for client certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,13 @@ The `connect()` method of the `MQTTClient` takes four optional parameters:
 2. Password
 3. A `ConnectionSettings` instance
 4. A `boolean` flag indicating whether a clean session should be requested (a random client id does this implicitly)
-5. A path to a client certificate .pem file to be used for TLS, optionally also including a private key (will be passed as PHP SSL context option 'local_cert')
-6. A path to a private key file to be used for TLS (will be passed as PHP SSL context option 'local_pk')
 
 Example:
 ```php
 $mqtt = new \PhpMqtt\Client\MQTTClient($server, $port, $clientId);
 
 $connectionSettings = new \PhpMqtt\Client\ConnectionSettings();
-$mqtt->connect($username, $password, $connectionSettings, true, '/home/user/cert.pem', '/home/user/private.key');
+$mqtt->connect($username, $password, $connectionSettings, true);
 ```
 
 The `ConnectionSettings` class has the following constructor and defaults:
@@ -125,7 +123,10 @@ public function __construct(
     string $lastWillMessage = null,
     bool $useTls = false,
     bool $tlsVerifyPeer = true,
-    bool $tlsVerifyName = true
+    bool $tlsVerifyName = true,
+    string $tlsClientCertificateFile = null,
+    string $tlsClientCertificateKeyFile = null,
+    string $tlsClientCertificatePassphrase = null
 ) { ... }
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,15 @@ The `connect()` method of the `MQTTClient` takes four optional parameters:
 2. Password
 3. A `ConnectionSettings` instance
 4. A `boolean` flag indicating whether a clean session should be requested (a random client id does this implicitly)
+5. A path to a client certificate .pem file to be used for TLS, optionally also including a private key (will be passed as PHP SSL context option 'local_cert')
+6. A path to a private key file to be used for TLS (will be passed as PHP SSL context option 'local_pk')
 
 Example:
 ```php
 $mqtt = new \PhpMqtt\Client\MQTTClient($server, $port, $clientId);
 
 $connectionSettings = new \PhpMqtt\Client\ConnectionSettings();
-$mqtt->connect($username, $password, $connectionSettings, true);
+$mqtt->connect($username, $password, $connectionSettings, true, '/home/user/cert.pem', '/home/user/private.key');
 ```
 
 The `ConnectionSettings` class has the following constructor and defaults:

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -265,7 +265,7 @@ class ConnectionSettings
      * passphrase is valid.
      * This method returns null if the configuration is valid or an array of errors
      * if the configuration is invalid.
-     * 
+     *
      * @return string[]|null
      */
     public function validateTlsClientCertificate(): ?array

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -239,10 +239,10 @@ class ConnectionSettings
     /**
      * Returns the full path to the configured client certificate file,
      * or null if none is configured.
-     * 
+     *
      * The client certificate can be of any format supported by the `local_cert`
      * option described by https://www.php.net/manual/en/context.ssl.php.
-     * 
+     *
      * @return string|null
      */
     public function getTlsClientCertificateFile(): ?string
@@ -253,10 +253,10 @@ class ConnectionSettings
     /**
      * Returns the full path to the configured client certificate key file,
      * or null if none is configured.
-     * 
+     *
      * The client certificate key can be of any format supported by the `local_pk`
      * option described by https://www.php.net/manual/en/context.ssl.php.
-     * 
+     *
      * @return string|null
      */
     public function getTlsClientCertificateKeyFile(): ?string
@@ -267,7 +267,7 @@ class ConnectionSettings
     /**
      * Returns the passphrase for the configured client certificate key,
      * or null if none is configured.
-     * 
+     *
      * @return string|null
      */
     public function getTlsClientCertificatePassphrase(): ?string

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -44,6 +44,15 @@ class ConnectionSettings
     /** @var bool */
     private $tlsVerifyName;
 
+    /** @var string|null */
+    private $tlsClientCertificateFile;
+
+    /** @var string|null */
+    private $tlsClientCertificateKeyFile;
+
+    /** @var string|null */
+    private $tlsClientCertificatePassphrase;
+
     /**
      * Constructs a new settings object.
      *
@@ -58,6 +67,9 @@ class ConnectionSettings
      * @param bool        $useTls
      * @param bool        $tlsVerifyPeer
      * @param bool        $tlsVerifyName
+     * @param string|null $tlsClientCertificateFile
+     * @param string|null $tlsClientCertificateKeyFile
+     * @param string|null $tlsClientCertificatePassphrase
      */
     public function __construct(
         int $qualityOfService = 0,
@@ -70,20 +82,26 @@ class ConnectionSettings
         string $lastWillMessage = null,
         bool $useTls = false,
         bool $tlsVerifyPeer = true,
-        bool $tlsVerifyName = true
+        bool $tlsVerifyName = true,
+        string $tlsClientCertificateFile = null,
+        string $tlsClientCertificateKeyFile = null,
+        string $tlsClientCertificatePassphrase = null
     )
     {
-        $this->qualityOfService = $qualityOfService;
-        $this->retain           = $retain;
-        $this->blockSocket      = $blockSocket;
-        $this->socketTimeout    = $socketTimeout;
-        $this->keepAlive        = $keepAlive;
-        $this->resendTimeout    = $resendTimeout;
-        $this->lastWillTopic    = $lastWillTopic;
-        $this->lastWillMessage  = $lastWillMessage;
-        $this->useTls           = $useTls;
-        $this->tlsVerifyPeer    = $tlsVerifyPeer;
-        $this->tlsVerifyName    = $tlsVerifyName;
+        $this->qualityOfService               = $qualityOfService;
+        $this->retain                         = $retain;
+        $this->blockSocket                    = $blockSocket;
+        $this->socketTimeout                  = $socketTimeout;
+        $this->keepAlive                      = $keepAlive;
+        $this->resendTimeout                  = $resendTimeout;
+        $this->lastWillTopic                  = $lastWillTopic;
+        $this->lastWillMessage                = $lastWillMessage;
+        $this->useTls                         = $useTls;
+        $this->tlsVerifyPeer                  = $tlsVerifyPeer;
+        $this->tlsVerifyName                  = $tlsVerifyName;
+        $this->tlsClientCertificateFile       = $tlsClientCertificateFile;
+        $this->tlsClientCertificateKeyFile    = $tlsClientCertificateKeyFile;
+        $this->tlsClientCertificatePassphrase = $tlsClientCertificatePassphrase;
     }
 
     /**
@@ -216,5 +234,60 @@ class ConnectionSettings
     public function shouldTlsVerifyPeerName(): bool
     {
         return $this->tlsVerifyName;
+    }
+    
+    /**
+     * @return string|null
+     */
+    public function getTlsClientCertificateFile(): ?string
+    {
+        return $this->tlsClientCertificateFile;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTlsClientCertificateKeyFile(): ?string
+    {
+        return $this->tlsClientCertificateKeyFile;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTlsClientCertificatePassphrase(): ?string
+    {
+        return $this->tlsClientCertificatePassphrase;
+    }
+
+    /**
+     * Checks if the configuration of the client certificate file, key file and
+     * passphrase is valid.
+     * This method returns null if the configuration is valid or an array of errors
+     * if the configuration is invalid.
+     * 
+     * @return string[]|null
+     */
+    public function validateTlsClientCertificate(): ?array
+    {
+        $errors = [];
+
+        if ($this->tlsClientCertificateFile !== null && !is_file($this->tlsClientCertificateFile)) {
+            $errors[] = 'The client certificate file setting must contain the path to a regular file.';
+        }
+
+        if ($this->tlsClientCertificateKeyFile !== null && !is_file($this->tlsClientCertificateKeyFile)) {
+            $errors[] = 'The client certificate key file setting must contain the path to a regular file.';
+        }
+
+        if ($this->tlsClientCertificateKeyFile !== null && $this->tlsClientCertificateFile === null) {
+            $errors[] = 'Using a client certificate key file without certificate does not work.';
+        }
+
+        if ($this->tlsClientCertificatePassphrase !== null && $this->tlsClientCertificateFile === null) {
+            $errors[] = 'Using a client certificate passphrase without certificate does not work.';
+        }
+
+        return count($errors) === 0 ? null : $errors;
     }
 }

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -237,6 +237,12 @@ class ConnectionSettings
     }
     
     /**
+     * Returns the full path to the configured client certificate file,
+     * or null if none is configured.
+     * 
+     * The client certificate can be of any format supported by the `local_cert`
+     * option described by https://www.php.net/manual/en/context.ssl.php.
+     * 
      * @return string|null
      */
     public function getTlsClientCertificateFile(): ?string
@@ -245,6 +251,12 @@ class ConnectionSettings
     }
 
     /**
+     * Returns the full path to the configured client certificate key file,
+     * or null if none is configured.
+     * 
+     * The client certificate key can be of any format supported by the `local_pk`
+     * option described by https://www.php.net/manual/en/context.ssl.php.
+     * 
      * @return string|null
      */
     public function getTlsClientCertificateKeyFile(): ?string
@@ -253,41 +265,13 @@ class ConnectionSettings
     }
 
     /**
+     * Returns the passphrase for the configured client certificate key,
+     * or null if none is configured.
+     * 
      * @return string|null
      */
     public function getTlsClientCertificatePassphrase(): ?string
     {
         return $this->tlsClientCertificatePassphrase;
-    }
-
-    /**
-     * Checks if the configuration of the client certificate file, key file and
-     * passphrase is valid.
-     * This method returns null if the configuration is valid or an array of errors
-     * if the configuration is invalid.
-     *
-     * @return string[]|null
-     */
-    public function validateTlsClientCertificate(): ?array
-    {
-        $errors = [];
-
-        if ($this->tlsClientCertificateFile !== null && !is_file($this->tlsClientCertificateFile)) {
-            $errors[] = 'The client certificate file setting must contain the path to a regular file.';
-        }
-
-        if ($this->tlsClientCertificateKeyFile !== null && !is_file($this->tlsClientCertificateKeyFile)) {
-            $errors[] = 'The client certificate key file setting must contain the path to a regular file.';
-        }
-
-        if ($this->tlsClientCertificateKeyFile !== null && $this->tlsClientCertificateFile === null) {
-            $errors[] = 'Using a client certificate key file without certificate does not work.';
-        }
-
-        if ($this->tlsClientCertificatePassphrase !== null && $this->tlsClientCertificateFile === null) {
-            $errors[] = 'Using a client certificate passphrase without certificate does not work.';
-        }
-
-        return count($errors) === 0 ? null : $errors;
     }
 }

--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -186,11 +186,11 @@ class MQTTClient implements ClientContract
             }
             
             if ($sslLocalCert !== null) {
-              $contextOptions['ssl']['local_cert'] = $sslLocalCert;
+                $contextOptions['ssl']['local_cert'] = $sslLocalCert;
             }
             
             if ($sslLocalPk !== null) {
-              $contextOptions['ssl']['local_pk'] = $sslLocalPk;
+                $contextOptions['ssl']['local_pk'] = $sslLocalPk;
             }
         }
 

--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -193,10 +193,10 @@ class MQTTClient implements ClientContract
                     $contextOptions['ssl']['passphrase'] = $this->settings->getTlsClientCertificatePassphrase();
                 }
             } else {
-              $this->logger->warning('Cannot use client certificate due to the following errors:');
-              foreach ($clientCertificateErrors as $validationError) {
-                  $this->logger->warning($validationError);
-              }
+                $this->logger->warning('Cannot use client certificate due to the following errors:');
+                foreach ($clientCertificateErrors as $validationError) {
+                    $this->logger->warning($validationError);
+                }
             }
         }
 

--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -125,6 +125,8 @@ class MQTTClient implements ClientContract
      * @param string|null             $password
      * @param ConnectionSettings|null $settings
      * @param bool                    $sendCleanSessionFlag
+     * @param string|null             $sslLocalCert
+     * @param string|null             $sslLocalPk
      * @return void
      * @throws ConnectingToBrokerFailedException
      */
@@ -132,7 +134,9 @@ class MQTTClient implements ClientContract
         string $username = null,
         string $password = null,
         ConnectionSettings $settings = null,
-        bool $sendCleanSessionFlag = false
+        bool $sendCleanSessionFlag = false,
+        string $sslLocalCert = null,
+        string $sslLocalPk = null
     ): void
     {
         // Always abruptly close any previous connection if we are opening a new one.
@@ -143,17 +147,19 @@ class MQTTClient implements ClientContract
 
         $this->settings = $settings ?? new ConnectionSettings();
 
-        $this->establishSocketConnection();
+        $this->establishSocketConnection($sslLocalCert, $sslLocalPk);
         $this->performConnectionHandshake($username, $password, $sendCleanSessionFlag);
     }
 
     /**
      * Opens a socket that connects to the host and port set on the object.
      *
+     * @param string|null $sslLocalCert
+     * @param string|null $sslLocalPk
      * @return void
      * @throws ConnectingToBrokerFailedException
      */
-    protected function establishSocketConnection(): void
+    protected function establishSocketConnection($sslLocalCert = null, $sslLocalPk = null): void
     {
         $useTls = ($this->settings->shouldUseTls() || $this->hasCertificateAuthorityFile());
 
@@ -177,6 +183,14 @@ class MQTTClient implements ClientContract
             if ($this->hasCertificateAuthorityFile()) {
                 $this->logger->info(sprintf('Using certificate authority file [%s] to verify peer name.', $this->getCertificateAuthorityFile()));
                 $contextOptions['ssl']['cafile'] = $this->getCertificateAuthorityFile();
+            }
+            
+            if ($sslLocalCert !== null) {
+              $contextOptions['ssl']['local_cert'] = $sslLocalCert;
+            }
+            
+            if ($sslLocalPk !== null) {
+              $contextOptions['ssl']['local_pk'] = $sslLocalPk;
             }
         }
 

--- a/src/MQTTClient.php
+++ b/src/MQTTClient.php
@@ -265,9 +265,9 @@ class MQTTClient implements ClientContract
      * Validates the TLS configuration of the client certificate. The configuration is considered valid
      * if the path to a valid certificate file, a valid key file and, if required, a passphrase is given.
      * A combined file with the client certificate and its key is not supported.
-     * 
+     *
      * If no configuration for a client certificate is given at all, the configuration is also valid.
-     * 
+     *
      * Warnings will be written to the log in case of an invalid configuration.
      *
      * @param ConnectionSettings $settings


### PR DESCRIPTION
Hello there,

I am creating this pull request after reading the following comment from Namoshek from https://github.com/php-mqtt/client/issues/34#issuecomment-675290524:
_'I would also be open for a pull request to add client certificate support to the 0.2 branch though!'_

I tried to use this library to connect to an MQTT Server from Amazon Web Services IoT, and finally managed to connect after adding some lines which set the 'local_cert' and 'local_key' properties on the SSL context. I'm not sure if the way I am passing the file paths to the MQTTClient class fits this libary's API design, so maybe someone familiar with this library could check if these changes could be merged into the project. Maybe it would be better to allow the caller to pass an array which will be merged into 
$contextOptions['ssl'] just before connecting. The changes are documented inside the README.md and don't break the library's public API as all new parameters are optional.