### PR TITLE
Run test workflow using different MQTT brokers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4', '8.0']
-        mqtt-broker: ['mosquitto', 'hivemq', 'emqx']
+        php-version: ['8.0']
+        mqtt-broker: ['mosquitto', 'hivemq']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,7 @@ jobs:
         uses: ifaxity/wait-on-action@v1
         with:
           resource: tcp:127.0.0.1:1883
+          delay: 5000
           timeout: 30000
 
       - name: Run phpunit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,14 +82,14 @@ jobs:
           MQTT_BROKER_PORT: 1883
 
       - name: Prepare paths for SonarQube analysis
-        if: matrix.php-version == '8.0'
+        if: matrix.php-version == '8.0' && matrix.mqtt-broker == 'mosquitto'
         run: |
           sed -i "s|$GITHUB_WORKSPACE|/github/workspace|g" phpunit.coverage-clover.xml
           sed -i "s|$GITHUB_WORKSPACE|/github/workspace|g" phpunit.report-junit.xml
 
       - name: Run SonarQube analysis
         uses: sonarsource/sonarcloud-github-action@master
-        if: matrix.php-version == '8.0'
+        if: matrix.php-version == '8.0' && matrix.mqtt-broker == 'mosquitto'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Ensure MQTT broker is listening
         uses: ifaxity/wait-on-action@v1
         with:
-          resource: 127.0.0.1:1883
+          resource: tcp:127.0.0.1:1883
           timeout: 30000
 
       - name: Run phpunit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.0']
-        mqtt-broker: ['mosquitto', 'hivemq']
+        php-version: ['7.4', '8.0']
+        mqtt-broker: ['mosquitto', 'hivemq', 'emqx']
 
     steps:
       - uses: actions/checkout@v2
@@ -72,12 +72,8 @@ jobs:
           version: '4.2.5'
           port: 1883
 
-      - name: Ensure MQTT broker is listening
-        uses: ifaxity/wait-on-action@v1
-        with:
-          resource: tcp:127.0.0.1:1883
-          delay: 5000
-          timeout: 30000
+      - name: Wait a bit until MQTT broker has started
+        run: sleep 15
 
       - name: Run phpunit tests
         run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   test-all:
-    name: Test PHP ${{ matrix.php-version }} on ${{ matrix.operating-system }}
+    name: Test PHP ${{ matrix.php-version }} using broker [${{ matrix.mqtt-broker }}]
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        operating-system: [ubuntu-latest]
         php-version: ['7.4', '8.0']
+        mqtt-broker: ['mosquitto', 'hivemq', 'emqx']
 
     steps:
       - uses: actions/checkout@v2
@@ -52,10 +52,31 @@ jobs:
         run: composer install --prefer-dist --ignore-platform-reqs
 
       - name: Start Mosquitto message broker
-        uses: Namoshek/mosquitto-github-action@v0.1.0
+        if: matrix.mqtt-broker == 'mosquitto'
+        uses: Namoshek/mosquitto-github-action@v0.2.0
+        with:
+          version: '1.6'
+          port: 1883
+
+      - name: Start HiveMQ message broker
+        if: matrix.mqtt-broker == 'hivemq'
+        uses: Namoshek/hivemq4-github-action@v0.1.0
+        with:
+          version: '4.4.4'
+          port: 1883
+
+      - name: Start EMQ X message broker
+        if: matrix.mqtt-broker == 'emqx'
+        uses: Namoshek/emqx-github-action@v0.1.0
+        with:
+          version: '4.2.5'
+          port: 1883
 
       - name: Run phpunit tests
         run: composer test
+        env:
+          MQTT_BROKER_HOST: '127.0.0.1'
+          MQTT_BROKER_PORT: 1883
 
       - name: Prepare paths for SonarQube analysis
         if: matrix.php-version == '8.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,12 @@ jobs:
           version: '4.2.5'
           port: 1883
 
+      - name: Ensure MQTT broker is listening
+        uses: ifaxity/wait-on-action@v1
+        with:
+          resource: 127.0.0.1:1883
+          timeout: 30000
+
       - name: Run phpunit tests
         run: composer test
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
           port: 1883
 
       - name: Wait a bit until MQTT broker has started
-        run: sleep 15
+        run: sleep 30
 
       - name: Run phpunit tests
         run: composer test

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
          enforceTimeLimit="true"
@@ -21,9 +21,9 @@
             <directory suffix="Test.php">tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,6 @@
     <php>
         <env name="MQTT_BROKER_HOST" value="127.0.0.1"/>
         <env name="MQTT_BROKER_PORT" value="1883"/>
-        <env name="MQTT_BROKER_TLS_PORT" value="8883"/>
     </php>
     <testsuites>
         <testsuite name="Unit">


### PR DESCRIPTION
This PR changes the test workflow in a way which will run the tests using different MQTT brokers (Mosquitto, HiveMQ 4 and EMQ X). Doing so can help reduce issues with individual brokers.