### PR TITLE
Rename close() to disconnect()

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $clientId = 'test-publisher';
 $mqtt = new \PhpMqtt\Client\MqttClient($server, $port, $clientId);
 $mqtt->connect();
 $mqtt->publish('php-mqtt/client/test', 'Hello World!', 0);
-$mqtt->close();
+$mqtt->disconnect();
 ```
 
 If you do not want to pass a `$clientId`, a random one will be generated for you. This will basically force a clean session implicitly.
@@ -57,6 +57,7 @@ $mqtt->subscribe('php-mqtt/client/test', function ($topic, $message) {
     echo sprintf("Received message on topic [%s]: %s\n", $topic, $message);
 }, 0);
 $mqtt->loop(true);
+$mqtt->disconnect();
 ```
 
 While the loop is active, you can use `$mqtt->interrupt()` to send an interrupt signal to the loop.
@@ -76,7 +77,7 @@ $mqtt->subscribe('php-mqtt/client/test', function ($topic, $message) {
     echo sprintf("Received message on topic [%s]: %s\n", $topic, $message);
 }, 0);
 $mqtt->loop(true);
-$mqtt->close();
+$mqtt->disconnect();
 ```
 
 ### Client Settings

--- a/src/Contracts/MqttClient.php
+++ b/src/Contracts/MqttClient.php
@@ -35,6 +35,14 @@ interface MqttClient
     ): void;
 
     /**
+     * Sends a disconnect message to the broker and closes the socket.
+     *
+     * @return void
+     * @throws DataTransferException
+     */
+    public function disconnect(): void;
+
+    /**
      * Returns an indication, whether the client is supposed to be connected already or not.
      *
      * Note: the result of this method should be used carefully, since we can only detect a
@@ -99,14 +107,6 @@ interface MqttClient
      * @throws DataTransferException
      */
     public function unsubscribe(string $topic): void;
-
-    /**
-     * Sends a disconnect and closes the socket.
-     *
-     * @return void
-     * @throws DataTransferException
-     */
-    public function close(): void;
 
     /**
      * Sets the interrupted signal. Doing so instructs the client to exit the loop, if it is

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -319,6 +319,7 @@ class MqttClient implements ClientContract
      *   - Connect acknowledgement with variable length
      *
      * @param bool $useCleanSession
+     * @return void
      * @throws ConnectingToBrokerFailedException
      */
     protected function performConnectionHandshake(bool $useCleanSession = false): void
@@ -467,20 +468,20 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Sends a disconnect and closes the socket.
+     * Sends a disconnect message to the broker and closes the socket.
      *
      * @return void
      * @throws DataTransferException
      */
-    public function close(): void
+    public function disconnect(): void
     {
         $this->ensureConnected();
 
-        $this->logger->debug('Closing the connection to the broker.');
-
-        $this->disconnect();
+        $this->sendDisconnect();
 
         if ($this->socket !== null && is_resource($this->socket)) {
+            $this->logger->debug('Closing the socket to the broker.');
+
             stream_socket_shutdown($this->socket, STREAM_SHUT_WR);
         }
 
@@ -527,6 +528,7 @@ class MqttClient implements ClientContract
      * @param bool     $retain
      * @param int|null $messageId
      * @param bool     $isDuplicate
+     * @return void
      * @throws DataTransferException
      */
     protected function publishMessage(
@@ -761,6 +763,7 @@ class MqttClient implements ClientContract
      * Handles the given message according to its contents.
      *
      * @param Message $message
+     * @return void
      * @throws DataTransferException
      * @throws ProtocolViolationException
      */
@@ -1080,6 +1083,7 @@ class MqttClient implements ClientContract
     /**
      * Sends a ping message to the broker to keep the connection alive.
      *
+     * @return void
      * @throws DataTransferException
      */
     protected function ping(): void
@@ -1092,9 +1096,10 @@ class MqttClient implements ClientContract
     /**
      * Sends a disconnect message to the broker. Does not close the socket.
      *
+     * @return void
      * @throws DataTransferException
      */
-    protected function disconnect(): void
+    protected function sendDisconnect(): void
     {
         $data = $this->messageProcessor->buildDisconnectMessage();
 


### PR DESCRIPTION
Since there is a `connect()` method, there should also be a `disconnect()` method. Until now, the `disconnect()` method was internal and used by `close()`. This PR renames `close()` to `disconnect()` and the internal `disconnect()` to `sendDisconnect()`.