### PR TITLE
Do not serialize subscription callbacks, remove subscription id and quality changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ $connectionSettings = (new \PhpMqtt\Client\ConnectionSettings())
   This also only affects QoS levels higher than 0, as QoS level 0 is a simple fire and forget mode.
 - Message flows with a QoS level higher than 0 are not persisted as the default implementation uses an in-memory repository for data.
   To avoid issues with broken message flows, use the clean session flag to indicate that you don't care about old data.
+  It will not only instruct the broker to consider the connection new (without previous state), but will also reset the registered repository.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "psr/log": "^1.1",
-        "myclabs/php-enum": "^1.7",
-        "opis/closure": "^3.5"
+        "myclabs/php-enum": "^1.7"
     },
     "require-dev": {
         "phpunit/php-invoker": "^3.0",

--- a/src/Concerns/OffersHooks.php
+++ b/src/Concerns/OffersHooks.php
@@ -57,13 +57,12 @@ trait OffersHooks
      * Multiple event handlers can be registered at the same time.
      *
      * @param \Closure $callback
-     * @return MqttClient
+     * @return self
      */
-    public function registerLoopEventHandler(\Closure $callback): MqttClient
+    public function registerLoopEventHandler(\Closure $callback): self
     {
         $this->loopEventHandlers->attach($callback);
 
-        /** @var MqttClient $this */
         return $this;
     }
 
@@ -75,9 +74,9 @@ trait OffersHooks
      * to unregister all registered event handlers by passing null as callback.
      *
      * @param \Closure|null $callback
-     * @return MqttClient
+     * @return self
      */
-    public function unregisterLoopEventHandler(\Closure $callback = null): MqttClient
+    public function unregisterLoopEventHandler(\Closure $callback = null): self
     {
         if ($callback === null) {
             $this->loopEventHandlers->removeAll($this->loopEventHandlers);
@@ -85,7 +84,6 @@ trait OffersHooks
             $this->loopEventHandlers->detach($callback);
         }
 
-        /** @var MqttClient $this */
         return $this;
     }
 
@@ -132,13 +130,12 @@ trait OffersHooks
      * Multiple event handlers can be registered at the same time.
      *
      * @param \Closure $callback
-     * @return MqttClient
+     * @return self
      */
-    public function registerPublishEventHandler(\Closure $callback): MqttClient
+    public function registerPublishEventHandler(\Closure $callback): self
     {
         $this->publishEventHandlers->attach($callback);
 
-        /** @var MqttClient $this */
         return $this;
     }
 
@@ -150,9 +147,9 @@ trait OffersHooks
      * to unregister all registered event handlers by passing null as callback.
      *
      * @param \Closure|null $callback
-     * @return MqttClient
+     * @return self
      */
-    public function unregisterPublishEventHandler(\Closure $callback = null): MqttClient
+    public function unregisterPublishEventHandler(\Closure $callback = null): self
     {
         if ($callback === null) {
             $this->publishEventHandlers->removeAll($this->publishEventHandlers);
@@ -160,7 +157,6 @@ trait OffersHooks
             $this->publishEventHandlers->detach($callback);
         }
 
-        /** @var MqttClient $this */
         return $this;
     }
 
@@ -212,13 +208,12 @@ trait OffersHooks
      * Multiple event handlers can be registered at the same time.
      *
      * @param \Closure $callback
-     * @return MqttClient
+     * @return self
      */
-    public function registerReceivedMessageEventHandler(\Closure $callback): MqttClient
+    public function registerReceivedMessageEventHandler(\Closure $callback): self
     {
         $this->receivedMessageEventHandlers->attach($callback);
 
-        /** @var MqttClient $this */
         return $this;
     }
 
@@ -229,9 +224,9 @@ trait OffersHooks
      * to unregister all registered event handlers by passing null as callback.
      *
      * @param \Closure|null $callback
-     * @return MqttClient
+     * @return self
      */
-    public function unregisterReceivedMessageEventHandler(\Closure $callback = null): MqttClient
+    public function unregisterReceivedMessageEventHandler(\Closure $callback = null): self
     {
         if ($callback === null) {
             $this->receivedMessageEventHandlers->removeAll($this->receivedMessageEventHandlers);
@@ -239,7 +234,6 @@ trait OffersHooks
             $this->receivedMessageEventHandlers->detach($callback);
         }
 
-        /** @var MqttClient $this */
         return $this;
     }
 

--- a/src/Concerns/OffersHooks.php
+++ b/src/Concerns/OffersHooks.php
@@ -21,7 +21,7 @@ trait OffersHooks
     private $publishEventHandlers;
 
     /** @var \SplObjectStorage|array<\Closure> */
-    private $receivedMessageEventHandlers;
+    private $messageReceivedEventHandlers;
 
     /**
      * Needs to be called in order to initialize the trait.
@@ -32,7 +32,7 @@ trait OffersHooks
     {
         $this->loopEventHandlers            = new \SplObjectStorage();
         $this->publishEventHandlers         = new \SplObjectStorage();
-        $this->receivedMessageEventHandlers = new \SplObjectStorage();
+        $this->messageReceivedEventHandlers = new \SplObjectStorage();
     }
 
     /**
@@ -57,12 +57,13 @@ trait OffersHooks
      * Multiple event handlers can be registered at the same time.
      *
      * @param \Closure $callback
-     * @return self
+     * @return MqttClient
      */
-    public function registerLoopEventHandler(\Closure $callback): self
+    public function registerLoopEventHandler(\Closure $callback): MqttClient
     {
         $this->loopEventHandlers->attach($callback);
 
+        /** @var MqttClient $this */
         return $this;
     }
 
@@ -74,9 +75,9 @@ trait OffersHooks
      * to unregister all registered event handlers by passing null as callback.
      *
      * @param \Closure|null $callback
-     * @return self
+     * @return MqttClient
      */
-    public function unregisterLoopEventHandler(\Closure $callback = null): self
+    public function unregisterLoopEventHandler(\Closure $callback = null): MqttClient
     {
         if ($callback === null) {
             $this->loopEventHandlers->removeAll($this->loopEventHandlers);
@@ -84,6 +85,7 @@ trait OffersHooks
             $this->loopEventHandlers->detach($callback);
         }
 
+        /** @var MqttClient $this */
         return $this;
     }
 
@@ -130,12 +132,13 @@ trait OffersHooks
      * Multiple event handlers can be registered at the same time.
      *
      * @param \Closure $callback
-     * @return self
+     * @return MqttClient
      */
-    public function registerPublishEventHandler(\Closure $callback): self
+    public function registerPublishEventHandler(\Closure $callback): MqttClient
     {
         $this->publishEventHandlers->attach($callback);
 
+        /** @var MqttClient $this */
         return $this;
     }
 
@@ -147,9 +150,9 @@ trait OffersHooks
      * to unregister all registered event handlers by passing null as callback.
      *
      * @param \Closure|null $callback
-     * @return self
+     * @return MqttClient
      */
-    public function unregisterPublishEventHandler(\Closure $callback = null): self
+    public function unregisterPublishEventHandler(\Closure $callback = null): MqttClient
     {
         if ($callback === null) {
             $this->publishEventHandlers->removeAll($this->publishEventHandlers);
@@ -157,6 +160,7 @@ trait OffersHooks
             $this->publishEventHandlers->detach($callback);
         }
 
+        /** @var MqttClient $this */
         return $this;
     }
 
@@ -188,7 +192,7 @@ trait OffersHooks
     /**
      * Registers an event handler which is called when a message is received from the broker.
      *
-     * The received message event handler is passed the MQTT client as first, the topic as
+     * The message received event handler is passed the MQTT client as first, the topic as
      * second and the message as third parameter. As fourth parameter, the QoS level will be
      * passed and the retained flag as fifth.
      *
@@ -208,37 +212,39 @@ trait OffersHooks
      * Multiple event handlers can be registered at the same time.
      *
      * @param \Closure $callback
-     * @return self
+     * @return MqttClient
      */
-    public function registerReceivedMessageEventHandler(\Closure $callback): self
+    public function registerMessageReceivedEventHandler(\Closure $callback): MqttClient
     {
-        $this->receivedMessageEventHandlers->attach($callback);
+        $this->messageReceivedEventHandlers->attach($callback);
 
+        /** @var MqttClient $this */
         return $this;
     }
 
     /**
-     * Unregisters a received message event handler which prevents it from being called in the future.
+     * Unregisters a message received event handler which prevents it from being called in the future.
      *
      * This does not affect other registered event handlers. It is possible
      * to unregister all registered event handlers by passing null as callback.
      *
      * @param \Closure|null $callback
-     * @return self
+     * @return MqttClient
      */
-    public function unregisterReceivedMessageEventHandler(\Closure $callback = null): self
+    public function unregisterMessageReceivedEventHandler(\Closure $callback = null): MqttClient
     {
         if ($callback === null) {
-            $this->receivedMessageEventHandlers->removeAll($this->receivedMessageEventHandlers);
+            $this->messageReceivedEventHandlers->removeAll($this->messageReceivedEventHandlers);
         } else {
-            $this->receivedMessageEventHandlers->detach($callback);
+            $this->messageReceivedEventHandlers->detach($callback);
         }
 
+        /** @var MqttClient $this */
         return $this;
     }
 
     /**
-     * Runs all the registered received message event handlers with the given parameters.
+     * Runs all the registered message received event handlers with the given parameters.
      * Each event handler is executed in a try-catch block to avoid spilling exceptions.
      *
      * @param string $topic
@@ -247,9 +253,9 @@ trait OffersHooks
      * @param bool   $retained
      * @return void
      */
-    private function runReceivedMessageEventHandlers(string $topic, string $message, int $qualityOfService, bool $retained): void
+    private function runMessageReceivedEventHandlers(string $topic, string $message, int $qualityOfService, bool $retained): void
     {
-        foreach ($this->receivedMessageEventHandlers as $handler) {
+        foreach ($this->messageReceivedEventHandlers as $handler) {
             try {
                 call_user_func($handler, $this, $topic, $message, $qualityOfService, $retained);
             } catch (\Throwable $e) {

--- a/src/Contracts/MqttClient.php
+++ b/src/Contracts/MqttClient.php
@@ -24,14 +24,14 @@ interface MqttClient
      * See {@see ConnectionSettings} for more details about the defaults.
      *
      * @param ConnectionSettings|null $settings
-     * @param bool                    $sendCleanSessionFlag
+     * @param bool                    $useCleanSession
      * @return void
      * @throws ConfigurationInvalidException
      * @throws ConnectingToBrokerFailedException
      */
     public function connect(
         ConnectionSettings $settings = null,
-        bool $sendCleanSessionFlag = false
+        bool $useCleanSession = false
     ): void;
 
     /**

--- a/src/Contracts/MqttClient.php
+++ b/src/Contracts/MqttClient.php
@@ -261,4 +261,42 @@ interface MqttClient
      * @return MqttClient
      */
     public function unregisterPublishEventHandler(\Closure $callback = null): MqttClient;
+
+    /**
+     * Registers an event handler which is called when a message is received from the broker.
+     *
+     * The received message event handler is passed the MQTT client as first, the topic as
+     * second and the message as third parameter. As fourth parameter, the QoS level will be
+     * passed and the retained flag as fifth.
+     *
+     * Example:
+     * ```php
+     * $mqtt->registerReceivedMessageEventHandler(function (
+     *     MqttClient $mqtt,
+     *     string $topic,
+     *     string $message,
+     *     int $qualityOfService,
+     *     bool $retained
+     * ) use ($logger) {
+     *     $logger->info("Received message on topic [{$topic}]: {$message}");
+     * });
+     * ```
+     *
+     * Multiple event handlers can be registered at the same time.
+     *
+     * @param \Closure $callback
+     * @return MqttClient
+     */
+    public function registerReceivedMessageEventHandler(\Closure $callback): MqttClient;
+
+    /**
+     * Unregisters a received message event handler which prevents it from being called in the future.
+     *
+     * This does not affect other registered event handlers. It is possible
+     * to unregister all registered event handlers by passing null as callback.
+     *
+     * @param \Closure|null $callback
+     * @return MqttClient
+     */
+    public function unregisterReceivedMessageEventHandler(\Closure $callback = null): MqttClient;
 }

--- a/src/Contracts/MqttClient.php
+++ b/src/Contracts/MqttClient.php
@@ -8,6 +8,7 @@ use PhpMqtt\Client\ConnectionSettings;
 use PhpMqtt\Client\Exceptions\ConfigurationInvalidException;
 use PhpMqtt\Client\Exceptions\ConnectingToBrokerFailedException;
 use PhpMqtt\Client\Exceptions\DataTransferException;
+use PhpMqtt\Client\Exceptions\MqttClientException;
 use PhpMqtt\Client\Exceptions\ProtocolViolationException;
 use PhpMqtt\Client\Exceptions\RepositoryException;
 
@@ -90,14 +91,17 @@ interface MqttClient
      * );
      * ```
      *
-     * @param string   $topicFilter
-     * @param callable $callback
-     * @param int      $qualityOfService
+     * If no callback is passed, a subscription will still be made. Received messages are delivered only to
+     * event handlers for received messages though.
+     *
+     * @param string        $topicFilter
+     * @param callable|null $callback
+     * @param int           $qualityOfService
      * @return void
      * @throws DataTransferException
      * @throws RepositoryException
      */
-    public function subscribe(string $topicFilter, callable $callback, int $qualityOfService = 0): void;
+    public function subscribe(string $topicFilter, callable $callback = null, int $qualityOfService = 0): void;
 
     /**
      * Unsubscribe from the given topic.
@@ -105,6 +109,7 @@ interface MqttClient
      * @param string $topicFilter
      * @return void
      * @throws DataTransferException
+     * @throws RepositoryException
      */
     public function unsubscribe(string $topicFilter): void;
 
@@ -138,6 +143,7 @@ interface MqttClient
      * @param int|null $queueWaitLimit
      * @return void
      * @throws DataTransferException
+     * @throws MqttClientException
      * @throws ProtocolViolationException
      */
     public function loop(bool $allowSleep = true, bool $exitWhenQueuesEmpty = false, int $queueWaitLimit = null): void;

--- a/src/Contracts/MqttClient.php
+++ b/src/Contracts/MqttClient.php
@@ -207,7 +207,7 @@ interface MqttClient
      * @param \Closure $callback
      * @return MqttClient
      */
-    public function registerLoopEventHandler(\Closure $callback): self;
+    public function registerLoopEventHandler(\Closure $callback): MqttClient;
 
     /**
      * Unregisters a loop event handler which prevents it from being called
@@ -219,7 +219,7 @@ interface MqttClient
      * @param \Closure|null $callback
      * @return MqttClient
      */
-    public function unregisterLoopEventHandler(\Closure $callback = null): self;
+    public function unregisterLoopEventHandler(\Closure $callback = null): MqttClient;
 
     /**
      * Registers a loop event handler which is called when a message is published.
@@ -248,7 +248,7 @@ interface MqttClient
      * @param \Closure $callback
      * @return MqttClient
      */
-    public function registerPublishEventHandler(\Closure $callback): self;
+    public function registerPublishEventHandler(\Closure $callback): MqttClient;
 
     /**
      * Unregisters a publish event handler which prevents it from being called
@@ -260,12 +260,12 @@ interface MqttClient
      * @param \Closure|null $callback
      * @return MqttClient
      */
-    public function unregisterPublishEventHandler(\Closure $callback = null): self;
+    public function unregisterPublishEventHandler(\Closure $callback = null): MqttClient;
 
     /**
      * Registers an event handler which is called when a message is received from the broker.
      *
-     * The received message event handler is passed the MQTT client as first, the topic as
+     * The message received event handler is passed the MQTT client as first, the topic as
      * second and the message as third parameter. As fourth parameter, the QoS level will be
      * passed and the retained flag as fifth.
      *
@@ -287,10 +287,10 @@ interface MqttClient
      * @param \Closure $callback
      * @return MqttClient
      */
-    public function registerReceivedMessageEventHandler(\Closure $callback): self;
+    public function registerMessageReceivedEventHandler(\Closure $callback): MqttClient;
 
     /**
-     * Unregisters a received message event handler which prevents it from being called in the future.
+     * Unregisters a message received event handler which prevents it from being called in the future.
      *
      * This does not affect other registered event handlers. It is possible
      * to unregister all registered event handlers by passing null as callback.
@@ -298,5 +298,5 @@ interface MqttClient
      * @param \Closure|null $callback
      * @return MqttClient
      */
-    public function unregisterReceivedMessageEventHandler(\Closure $callback = null): self;
+    public function unregisterMessageReceivedEventHandler(\Closure $callback = null): MqttClient;
 }

--- a/src/Contracts/MqttClient.php
+++ b/src/Contracts/MqttClient.php
@@ -207,7 +207,7 @@ interface MqttClient
      * @param \Closure $callback
      * @return MqttClient
      */
-    public function registerLoopEventHandler(\Closure $callback): MqttClient;
+    public function registerLoopEventHandler(\Closure $callback): self;
 
     /**
      * Unregisters a loop event handler which prevents it from being called
@@ -219,7 +219,7 @@ interface MqttClient
      * @param \Closure|null $callback
      * @return MqttClient
      */
-    public function unregisterLoopEventHandler(\Closure $callback = null): MqttClient;
+    public function unregisterLoopEventHandler(\Closure $callback = null): self;
 
     /**
      * Registers a loop event handler which is called when a message is published.
@@ -248,7 +248,7 @@ interface MqttClient
      * @param \Closure $callback
      * @return MqttClient
      */
-    public function registerPublishEventHandler(\Closure $callback): MqttClient;
+    public function registerPublishEventHandler(\Closure $callback): self;
 
     /**
      * Unregisters a publish event handler which prevents it from being called
@@ -260,7 +260,7 @@ interface MqttClient
      * @param \Closure|null $callback
      * @return MqttClient
      */
-    public function unregisterPublishEventHandler(\Closure $callback = null): MqttClient;
+    public function unregisterPublishEventHandler(\Closure $callback = null): self;
 
     /**
      * Registers an event handler which is called when a message is received from the broker.
@@ -287,7 +287,7 @@ interface MqttClient
      * @param \Closure $callback
      * @return MqttClient
      */
-    public function registerReceivedMessageEventHandler(\Closure $callback): MqttClient;
+    public function registerReceivedMessageEventHandler(\Closure $callback): self;
 
     /**
      * Unregisters a received message event handler which prevents it from being called in the future.
@@ -298,5 +298,5 @@ interface MqttClient
      * @param \Closure|null $callback
      * @return MqttClient
      */
-    public function unregisterReceivedMessageEventHandler(\Closure $callback = null): MqttClient;
+    public function unregisterReceivedMessageEventHandler(\Closure $callback = null): self;
 }

--- a/src/Contracts/Repository.php
+++ b/src/Contracts/Repository.php
@@ -28,6 +28,15 @@ use PhpMqtt\Client\Subscription;
 interface Repository
 {
     /**
+     * Re-initializes the repository by deleting all persisted data and restoring the original state,
+     * which was given when the repository was first created. This is used when a clean session
+     * is requested by a client during connection.
+     *
+     * @return bool
+     */
+    public function reset(): void;
+
+    /**
      * Returns a new message id. The message id might have been used before,
      * but it is currently not being used (i.e. in a resend queue).
      *

--- a/src/Contracts/Repository.php
+++ b/src/Contracts/Repository.php
@@ -149,13 +149,12 @@ interface Repository
     public function addSubscription(Subscription $subscription): void;
 
     /**
-     * Gets all subscriptions matching the given criteria.
+     * Gets all subscriptions matching the given topic.
      *
-     * @param string|null $topicName
-     * @param int|null    $subscriptionId
+     * @param string $topicName
      * @return Subscription[]
      */
-    public function getMatchingSubscriptions(string $topicName = null, int $subscriptionId = null): array;
+    public function getSubscriptionsMatchingTopic(string $topicName): array;
 
     /**
      * Removes the subscription with the given topic filter from the repository.

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -114,14 +114,14 @@ class MqttClient implements ClientContract
      * replaced with the new one, as `disconnect()` should be called first.
      *
      * @param ConnectionSettings|null $settings
-     * @param bool                    $sendCleanSessionFlag
+     * @param bool                    $useCleanSession
      * @return void
      * @throws ConfigurationInvalidException
      * @throws ConnectingToBrokerFailedException
      */
     public function connect(
         ConnectionSettings $settings = null,
-        bool $sendCleanSessionFlag = false
+        bool $useCleanSession = false
     ): void
     {
         // Always abruptly close any previous connection if we are opening a new one.
@@ -134,9 +134,14 @@ class MqttClient implements ClientContract
 
         $this->ensureConnectionSettingsAreValid($this->settings);
 
+        // When a clean session is requested, we have to reset the repository to forget about persisted states.
+        if ($useCleanSession) {
+            $this->repository->reset();
+        }
+
         try {
             $this->establishSocketConnection();
-            $this->performConnectionHandshake($sendCleanSessionFlag);
+            $this->performConnectionHandshake($useCleanSession);
         } catch (ConnectingToBrokerFailedException $e) {
             if ($this->socket !== null) {
                 $this->closeSocket();

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -11,7 +11,6 @@ use PhpMqtt\Client\Contracts\MessageProcessor;
 use PhpMqtt\Client\Contracts\MqttClient as ClientContract;
 use PhpMqtt\Client\Contracts\Repository;
 use PhpMqtt\Client\Exceptions\ClientNotConnectedToBrokerException;
-use PhpMqtt\Client\Exceptions\ConfigurationInvalidException;
 use PhpMqtt\Client\Exceptions\ConnectingToBrokerFailedException;
 use PhpMqtt\Client\Exceptions\DataTransferException;
 use PhpMqtt\Client\Exceptions\InvalidMessageException;
@@ -20,7 +19,6 @@ use PhpMqtt\Client\Exceptions\PendingMessageAlreadyExistsException;
 use PhpMqtt\Client\Exceptions\PendingMessageNotFoundException;
 use PhpMqtt\Client\Exceptions\ProtocolNotSupportedException;
 use PhpMqtt\Client\Exceptions\ProtocolViolationException;
-use PhpMqtt\Client\Exceptions\RepositoryException;
 use PhpMqtt\Client\MessageProcessors\Mqtt31MessageProcessor;
 use PhpMqtt\Client\Repositories\MemoryRepository;
 use Psr\Log\LoggerInterface;
@@ -106,18 +104,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Connect to the MQTT broker using the given credentials and settings.
-     * If no custom settings are passed, the client will use the default settings.
-     * See {@see ConnectionSettings} for more details about the defaults.
-     *
-     * In case there is an existing connection, it will be abruptly closed and
-     * replaced with the new one, as `disconnect()` should be called first.
-     *
-     * @param ConnectionSettings|null $settings
-     * @param bool                    $useCleanSession
-     * @return void
-     * @throws ConfigurationInvalidException
-     * @throws ConnectingToBrokerFailedException
+     * {@inheritDoc}
      */
     public function connect(
         ConnectionSettings $settings = null,
@@ -378,13 +365,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Sets the interrupted signal. Doing so instructs the client to exit the loop, if it is
-     * actually looping.
-     *
-     * Sending multiple interrupt signals has no effect, unless the client exits the loop,
-     * which resets the signal for another loop.
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function interrupt(): void
     {
@@ -392,9 +373,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Returns the host used by the client to connect to.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getHost(): string
     {
@@ -402,9 +381,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Returns the port used by the client to connect to.
-     *
-     * @return int
+     * {@inheritDoc}
      */
     public function getPort(): int
     {
@@ -412,9 +389,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Returns the identifier used by the client.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getClientId(): string
     {
@@ -422,9 +397,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Returns the total number of received bytes, across reconnects.
-     *
-     * @return int
+     * {@inheritDoc}
      */
     public function getReceivedBytes(): int
     {
@@ -432,9 +405,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Returns the total number of sent bytes, across reconnects.
-     *
-     * @return int
+     * {@inheritDoc}
      */
     public function getSentBytes(): int
     {
@@ -442,14 +413,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Returns an indication, whether the client is supposed to be connected already or not.
-     *
-     * Note: the result of this method should be used carefully, since we can only detect a
-     * closed socket once we try to send or receive data. Therefore, this method only gives
-     * an indication whether the client is in a connected state or not.
-     * This information may be useful in applications where multiple parts use the client.
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function isConnected(): bool
     {
@@ -473,10 +437,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Sends a disconnect message to the broker and closes the socket.
-     *
-     * @return void
-     * @throws DataTransferException
+     * {@inheritDoc}
      */
     public function disconnect(): void
     {
@@ -494,17 +455,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Publishes the given message on the given topic. If the additional quality of service
-     * and retention flags are set, the message will be published using these settings.
-     *
-     * @param string $topic
-     * @param string $message
-     * @param int    $qualityOfService
-     * @param bool   $retain
-     * @return void
-     * @throws DataTransferException
-     * @throws PendingMessageAlreadyExistsException
-     * @throws RepositoryException
+     * {@inheritDoc}
      */
     public function publish(string $topic, string $message, int $qualityOfService = 0, bool $retain = false): void
     {
@@ -562,34 +513,9 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Subscribe to the given topic with the given quality of service.
-     *
-     * The subscription callback is passed the topic as first and the message as second
-     * parameter. A third parameter indicates whether the received message has been sent
-     * because it was retained by the broker.
-     *
-     * Example:
-     * ```php
-     * $mqtt->subscribe(
-     *     '/foo/bar/+',
-     *     function (string $topic, string $message, bool $retained) use ($logger) {
-     *         $logger->info("Received {retained} message on topic [{topic}]: {message}", [
-     *             'topic' => $topic,
-     *             'message' => $message,
-     *             'retained' => $retained ? 'retained' : 'live'
-     *         ]);
-     *     }
-     * );
-     * ```
-     *
-     * @param string   $topicFilter
-     * @param callable $callback
-     * @param int      $qualityOfService
-     * @return void
-     * @throws DataTransferException
-     * @throws RepositoryException
+     * {@inheritDoc}
      */
-    public function subscribe(string $topicFilter, callable $callback, int $qualityOfService = self::QOS_AT_MOST_ONCE): void
+    public function subscribe(string $topicFilter, callable $callback = null, int $qualityOfService = self::QOS_AT_MOST_ONCE): void
     {
         $this->ensureConnected();
 
@@ -612,12 +538,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Unsubscribe from the given topic.
-     *
-     * @param string $topicFilter
-     * @return void
-     * @throws DataTransferException
-     * @throws RepositoryException
+     * {@inheritDoc}
      */
     public function unsubscribe(string $topicFilter): void
     {
@@ -646,25 +567,7 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Runs an event loop that handles messages from the server and calls the registered
-     * callbacks for published messages.
-     *
-     * If the second parameter is provided, the loop will exit as soon as all
-     * queues are empty. This means there may be no open subscriptions,
-     * no pending messages as well as acknowledgments and no pending unsubscribe requests.
-     *
-     * The third parameter will, if set, lead to a forceful exit after the specified
-     * amount of seconds, but only if the second parameter is set to true. This basically
-     * means that if we wait for all pending messages to be acknowledged, we only wait
-     * a maximum of $queueWaitLimit seconds until we give up. We do not exit after the
-     * given amount of time if there are open topic subscriptions though.
-     *
-     * @param bool     $allowSleep
-     * @param bool     $exitWhenQueuesEmpty
-     * @param int|null $queueWaitLimit
-     * @return void
-     * @throws DataTransferException
-     * @throws MqttClientException
+     * {@inheritDoc}
      */
     public function loop(bool $allowSleep = true, bool $exitWhenQueuesEmpty = false, int $queueWaitLimit = null): void
     {

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -875,6 +875,8 @@ class MqttClient implements ClientContract
                 ]);
             }
         }
+
+        $this->runReceivedMessageEventHandlers($topic, $message, $qualityOfServiceLevel, $retained);
     }
 
     /**

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -597,7 +597,7 @@ class MqttClient implements ClientContract
 
         // Create the subscription representation now, but it will become an
         // actual subscription only upon acknowledgement from the broker.
-        $subscriptions = [new Subscription($topicFilter, null, $callback, $qualityOfService)];
+        $subscriptions = [new Subscription($topicFilter, $qualityOfService, $callback)];
 
         $pendingMessage = new SubscribeRequest($messageId, $subscriptions);
         $this->repository->addPendingOutgoingMessage($pendingMessage);

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -861,6 +861,10 @@ class MqttClient implements ClientContract
         ]);
 
         foreach ($subscribers as $subscriber) {
+            if ($subscriber->getCallback() === null) {
+                continue;
+            }
+
             try {
                 call_user_func($subscriber->getCallback(), $topic, $message, $retained);
             } catch (\Throwable $e) {

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -876,7 +876,7 @@ class MqttClient implements ClientContract
             }
         }
 
-        $this->runReceivedMessageEventHandlers($topic, $message, $qualityOfServiceLevel, $retained);
+        $this->runMessageReceivedEventHandlers($topic, $message, $qualityOfServiceLevel, $retained);
     }
 
     /**

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -943,7 +943,7 @@ class MqttClient implements ClientContract
      */
     protected function deliverPublishedMessage(string $topic, string $message, int $qualityOfServiceLevel, bool $retained = false): void
     {
-        $subscribers = $this->repository->getMatchingSubscriptions($topic);
+        $subscribers = $this->repository->getSubscriptionsMatchingTopic($topic);
 
         $this->logger->debug('Delivering message received on topic [{topic}] with QoS [{qos}] from the broker to [{subscribers}] subscribers.', [
             'topic' => $topic,

--- a/src/Repositories/MemoryRepository.php
+++ b/src/Repositories/MemoryRepository.php
@@ -194,7 +194,7 @@ class MemoryRepository implements Repository
         $result = [];
 
         foreach ($this->subscriptions as $subscription) {
-            if (($topicName !== null) && !$subscription->matchTopicFilter($topicName)) {
+            if (($topicName !== null) && !$subscription->matchesTopic($topicName)) {
                 continue;
             }
 

--- a/src/Repositories/MemoryRepository.php
+++ b/src/Repositories/MemoryRepository.php
@@ -34,6 +34,17 @@ class MemoryRepository implements Repository
     /**
      * {@inheritDoc}
      */
+    public function reset(): void
+    {
+        $this->nextMessageId           = 1;
+        $this->pendingOutgoingMessages = [];
+        $this->pendingIncomingMessages = [];
+        $this->subscriptions           = [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function newMessageId(): int
     {
         if (count($this->pendingOutgoingMessages) >= 65535) {

--- a/src/Repositories/MemoryRepository.php
+++ b/src/Repositories/MemoryRepository.php
@@ -32,10 +32,7 @@ class MemoryRepository implements Repository
     private array $subscriptions = [];
 
     /**
-     * Returns a new message id. The message id might have been used before,
-     * but it is currently not being used (i.e. in a resend queue).
-     *
-     * @return int
+     * {@inheritDoc}
      */
     public function newMessageId(): int
     {
@@ -189,16 +186,12 @@ class MemoryRepository implements Repository
     /**
      * {@inheritDoc}
      */
-    public function getMatchingSubscriptions(string $topicName = null, int $subscriptionId = null): array
+    public function getSubscriptionsMatchingTopic(string $topicName): array
     {
         $result = [];
 
         foreach ($this->subscriptions as $subscription) {
-            if (($topicName !== null) && !$subscription->matchesTopic($topicName)) {
-                continue;
-            }
-
-            if (($subscriptionId !== null) && ($subscription->getSubscriptionId() !== $subscriptionId)) {
+            if ($topicName !== null && !$subscription->matchesTopic($topicName)) {
                 continue;
             }
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -15,7 +15,6 @@ class Subscription
     private string $regexifiedTopicFilter;
     private int $qualityOfService;
     private ?\Closure $callback;
-    private ?int $subscriptionId;
 
     /**
      * Creates a new subscription object.
@@ -23,14 +22,12 @@ class Subscription
      * @param string        $topicFilter
      * @param int           $qualityOfService
      * @param \Closure|null $callback
-     * @param int|null      $subscriptionId
      */
-    public function __construct(string $topicFilter, int $qualityOfService = 0, ?\Closure $callback = null, ?int $subscriptionId = null)
+    public function __construct(string $topicFilter, int $qualityOfService = 0, ?\Closure $callback = null)
     {
         $this->topicFilter      = $topicFilter;
         $this->qualityOfService = $qualityOfService;
         $this->callback         = $callback;
-        $this->subscriptionId   = $subscriptionId;
 
         $this->regexifyTopicFilter();
     }
@@ -64,16 +61,6 @@ class Subscription
     public function matchesTopic(string $topicName): bool
     {
         return (bool) preg_match($this->regexifiedTopicFilter, $topicName);
-    }
-
-    /**
-     * Returns the subscription identifier.
-     *
-     * @return int|null
-     */
-    public function getSubscriptionId(): ?int
-    {
-        return $this->subscriptionId;
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMqtt\Client;
 
-use Opis\Closure\SerializableClosure;
-
 /**
  * A simple DTO for subscriptions to a topic which need to be stored in a repository.
  *
@@ -14,27 +12,25 @@ use Opis\Closure\SerializableClosure;
 class Subscription
 {
     private string $topicFilter;
-    private ?int $subscriptionId;
-    private int $qualityOfService;
-    private ?SerializableClosure $callback = null;
     private string $regexifiedTopicFilter;
+    private int $qualityOfService;
+    private ?\Closure $callback;
+    private ?int $subscriptionId;
 
     /**
      * Creates a new subscription object.
      *
      * @param string        $topicFilter
-     * @param \Closure|null $callback
      * @param int           $qualityOfService
+     * @param \Closure|null $callback
+     * @param int|null      $subscriptionId
      */
-    public function __construct(string $topicFilter, ?int $subscriptionId, ?\Closure $callback, int $qualityOfService = 0)
+    public function __construct(string $topicFilter, int $qualityOfService = 0, ?\Closure $callback = null, ?int $subscriptionId = null)
     {
         $this->topicFilter      = $topicFilter;
-        $this->subscriptionId   = $subscriptionId;
         $this->qualityOfService = $qualityOfService;
-
-        if ($callback !== null) {
-            $this->callback = SerializableClosure::from($callback);
-        }
+        $this->callback         = $callback;
+        $this->subscriptionId   = $subscriptionId;
 
         $this->regexifyTopicFilter();
     }
@@ -65,7 +61,7 @@ class Subscription
      * @param string $topicName
      * @return bool
      */
-    public function matchTopicFilter(string $topicName): bool
+    public function matchesTopic(string $topicName): bool
     {
         return (bool) preg_match($this->regexifiedTopicFilter, $topicName);
     }
@@ -87,7 +83,7 @@ class Subscription
      */
     public function getCallback(): ?\Closure
     {
-        return ($this->callback ? $this->callback->getClosure() : null);
+        return $this->callback;
     }
 
     /**

--- a/tests/Feature/MessageReceivedEventHandlerTest.php
+++ b/tests/Feature/MessageReceivedEventHandlerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use PhpMqtt\Client\MqttClient;
+use Tests\TestCase;
+
+/**
+ * Tests that the message received event handler work as intended.
+ *
+ * @package Tests\Feature
+ */
+class MessageReceivedEventHandlerTest extends TestCase
+{
+    public function test_message_received_event_handlers_are_called_for_each_received_message(): void
+    {
+        // We connect and subscribe to a topic using the first client.
+        $subscriber = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'subscriber');
+        $subscriber->connect(null, true);
+
+        $handlerCallCount = 0;
+        $handler = function (MqttClient $client, string $topic, string $message, int $qualityOfService, bool $retained) use (&$handlerCallCount) {
+            $handlerCallCount++;
+
+            $this->assertSame('foo/bar/baz', $topic);
+            $this->assertSame('hello world', $message);
+            $this->assertSame(0, $qualityOfService);
+            $this->assertFalse($retained);
+
+            $client->interrupt();
+        };
+
+        $subscriber->registerMessageReceivedEventHandler($handler);
+        $subscriber->subscribe('foo/bar/baz');
+
+        // We publish a message from a second client on the same topic.
+        $publisher = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'publisher');
+        $publisher->connect(null, true);
+
+        $publisher->publish('foo/bar/baz', 'hello world', 0, false);
+
+        // Then we loop on the subscriber to (hopefully) receive the published message.
+        $subscriber->loop(true);
+
+        $this->assertSame(1, $handlerCallCount);
+
+        // Finally, we disconnect for a graceful shutdown on the broker side.
+        $publisher->disconnect();
+        $subscriber->disconnect();
+    }
+
+    public function test_message_received_event_handlers_can_be_unregistered_and_will_not_be_called_anymore(): void
+    {
+        // We connect and subscribe to a topic using the first client.
+        $subscriber = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'subscriber');
+        $subscriber->connect(null, true);
+
+        $handlerCallCount = 0;
+        $handler = function (MqttClient $client, string $topic, string $message, int $qualityOfService, bool $retained) use (&$handlerCallCount) {
+            $handlerCallCount++;
+
+            $this->assertSame('foo/bar/baz/01', $topic);
+            $this->assertSame('hello world', $message);
+            $this->assertSame(0, $qualityOfService);
+            $this->assertFalse($retained);
+
+            $client->unregisterMessageReceivedEventHandler();
+            $client->interrupt();
+        };
+
+        $subscriber->registerMessageReceivedEventHandler($handler);
+        $subscriber->subscribe('foo/bar/baz/+');
+
+        // We publish a message from a second client on the same topic.
+        $publisher = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'publisher');
+        $publisher->connect(null, true);
+
+        $publisher->publish('foo/bar/baz/01', 'hello world', 0, false);
+        $publisher->publish('foo/bar/baz/02', 'hello world', 0, false);
+
+        // Then we loop on the subscriber to (hopefully) receive the published message.
+        $subscriber->loop(true);
+
+        $this->assertSame(1, $handlerCallCount);
+
+        // Finally, we disconnect for a graceful shutdown on the broker side.
+        $publisher->disconnect();
+        $subscriber->disconnect();
+    }
+
+    public function test_message_received_event_handlers_can_throw_exceptions_which_does_not_affect_other_handlers_or_the_application(): void
+    {
+        // We connect and subscribe to a topic using the first client.
+        $subscriber = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'subscriber');
+        $subscriber->connect(null, true);
+
+        $handlerCallCount = 0;
+        $handler1 = function () {
+            throw new \Exception('Something went wrong!');
+        };
+        $handler2 = function (MqttClient $client) use (&$handlerCallCount) {
+            $handlerCallCount++;
+
+            $client->interrupt();
+        };
+
+        $subscriber->registerMessageReceivedEventHandler($handler1);
+        $subscriber->registerMessageReceivedEventHandler($handler2);
+        $subscriber->subscribe('foo/bar/baz');
+
+        // We publish a message from a second client on the same topic.
+        $publisher = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'publisher');
+        $publisher->connect(null, true);
+
+        $publisher->publish('foo/bar/baz', 'hello world', 0, false);
+
+        // Then we loop on the subscriber to (hopefully) receive the published message.
+        $subscriber->loop(true);
+
+        $this->assertSame(1, $handlerCallCount);
+
+        // Finally, we disconnect for a graceful shutdown on the broker side.
+        $publisher->disconnect();
+        $subscriber->disconnect();
+    }
+}

--- a/tests/Unit/MessageProcessors/Mqtt31MessageProcessorTest.php
+++ b/tests/Unit/MessageProcessors/Mqtt31MessageProcessorTest.php
@@ -159,13 +159,13 @@ class Mqtt31MessageProcessorTest extends TestCase
 
         return [
             // Simple QoS 0 subscription
-            [42, [new Subscription('test/foo', null, null, 0)], hex2bin('82'.'0d00'.'2a00'.'08') . 'test/foo' . hex2bin('00')],
+            [42, [new Subscription('test/foo', 0)], hex2bin('82'.'0d00'.'2a00'.'08') . 'test/foo' . hex2bin('00')],
 
             // Wildcard QoS 2 subscription with high message id
-            [43764, [new Subscription('test/foo/bar/baz/#', null, null, 2)], hex2bin('82'.'17aa'.'f400'.'12') . 'test/foo/bar/baz/#' . hex2bin('02')],
+            [43764, [new Subscription('test/foo/bar/baz/#', 2)], hex2bin('82'.'17aa'.'f400'.'12') . 'test/foo/bar/baz/#' . hex2bin('02')],
 
             // Long QoS 1 subscription with high message id
-            [62304, [new Subscription($longTopic, null, null, 1)], hex2bin('82'.'8701'.'f360'.'0082') . $longTopic . hex2bin('01')],
+            [62304, [new Subscription($longTopic, 1)], hex2bin('82'.'8701'.'f360'.'0082') . $longTopic . hex2bin('01')],
         ];
     }
 


### PR DESCRIPTION
Serializing callbacks will not work with resources and similar types of code. The subscription id is currently not required and useable (MQTT 5 feature). When a clean session is used, the repository is cleared. Adds event handlers for received messages (can be used in combination with subscriptions without callback for example, or for logging). Other changes affect the overall code quality.