### PR TITLE
Add support for shared subscription topic names

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -39,7 +39,17 @@ class Subscription
      */
     private function regexifyTopicFilter(): void
     {
-        $this->regexifiedTopicFilter = '/^' . str_replace(['$', '/', '+', '#'], ['\$', '\/', '[^\/]*', '.*'], $this->topicFilter) . '$/';
+        $topicFilter = $this->topicFilter;
+
+        // If the topic filter is for a shared subscription, we remove the shared subscription prefix as well as the group name
+        // from the topic filter. To do so, we look for the $share keyword and then try to find the second topic separator to
+        // calculate the substring containing the actual topic filter.
+        // Note: shared subscriptions always have the form: $share/<group>/<topic>
+        if (strpos($topicFilter, '$share/') === 0 && ($separatorIndex = strpos($topicFilter, '/', 7)) !== false) {
+            $topicFilter = substr($topicFilter, $separatorIndex + 1);
+        }
+
+        $this->regexifiedTopicFilter = '/^' . str_replace(['$', '/', '+', '#'], ['\$', '\/', '[^\/]*', '.*'], $topicFilter) . '$/';
     }
 
     /**


### PR DESCRIPTION
With MQTT 5, support for _shared subscriptions_ has been added to the MQTT protocol. Since this is pretty much a server-side feature only, where the server has to distribute messages across clients within a group, the only thing a client needs to consider is the `$share/<group>` part of used topic filters. This allows us back-porting this feature to MQTT 3 on the client side.

This PR therefore adds support for such topic filters by stripping the `$share/<group>` part for the comparison during regexification of the topic filter in the repository. While shared subscriptions are not an MQTT 3 feature, [usage of topic names beginning with `$` is discouraged](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718108). We can therefore assume that our users are not using topics with such a name, which allows us to keep backwards-compatibility.

Using a shared subscription is straight forward. Subscribing to the topic `foo/+` with the group `mygroup` would look like this:
```php
$client->subscribe('$share/mygroup/foo/+', fn (string $topic, string $message) => $logger->info('Message received'));
```

The new feature is covered by an integration test with two subscribers and a single publisher.