### PR TITLE
Add support for MQTT 3.1.1

### DIFF
--- a/src/MessageProcessors/Mqtt311MessageProcessor.php
+++ b/src/MessageProcessors/Mqtt311MessageProcessor.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMqtt\Client\MessageProcessors;
+
+use PhpMqtt\Client\ConnectionSettings;
+use Psr\Log\LoggerInterface;
+
+/**
+ * This message processor implements the MQTT protocol version 3.1.1.
+ *
+ * @package PhpMqtt\Client\MessageProcessors
+ */
+class Mqtt311MessageProcessor extends Mqtt31MessageProcessor
+{
+    private string $clientId;
+
+    /**
+     * Creates a new message processor instance which supports version 3.1.1 of the MQTT protocol.
+     *
+     * @param string          $clientId
+     * @param LoggerInterface $logger
+     */
+    public function __construct(string $clientId, LoggerInterface $logger)
+    {
+        parent::__construct($clientId, $logger);
+
+        $this->clientId = $clientId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function buildConnectMessage(ConnectionSettings $connectionSettings, bool $useCleanSession = false): string
+    {
+        // The protocol name and version.
+        $buffer  = $this->buildLengthPrefixedString('MQTT');
+        $buffer .= chr(0x04); // protocol version (4)
+
+        // Build connection flags based on the connection settings.
+        $buffer .= chr($this->buildConnectionFlags($connectionSettings, $useCleanSession));
+
+        // Encode and add the keep alive interval.
+        $buffer .= chr($connectionSettings->getKeepAliveInterval() >> 8);
+        $buffer .= chr($connectionSettings->getKeepAliveInterval() & 0xff);
+
+        // Encode and add the client identifier.
+        $buffer .= $this->buildLengthPrefixedString($this->clientId);
+
+        // Encode and add the last will topic and message, if configured.
+        if ($connectionSettings->hasLastWill()) {
+            $buffer .= $this->buildLengthPrefixedString($connectionSettings->getLastWillTopic());
+            $buffer .= $this->buildLengthPrefixedString($connectionSettings->getLastWillMessage());
+        }
+
+        // Encode and add the credentials, if configured.
+        if ($connectionSettings->getUsername() !== null) {
+            $buffer .= $this->buildLengthPrefixedString($connectionSettings->getUsername());
+        }
+        if ($connectionSettings->getPassword() !== null) {
+            $buffer .= $this->buildLengthPrefixedString($connectionSettings->getPassword());
+        }
+
+        // The header consists of the message type 0x10 and the length.
+        $header = chr(0x10) . $this->encodeMessageLength(strlen($buffer));
+
+        return $header . $buffer;
+    }
+}

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -86,7 +86,7 @@ class MqttClient implements ClientContract
         LoggerInterface $logger = null
     )
     {
-        if (!in_array($protocol, [self::MQTT_3_1])) {
+        if (!in_array($protocol, [self::MQTT_3_1, self::MQTT_3_1_1])) {
             throw new ProtocolNotSupportedException($protocol);
         }
 

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -19,6 +19,7 @@ use PhpMqtt\Client\Exceptions\PendingMessageAlreadyExistsException;
 use PhpMqtt\Client\Exceptions\PendingMessageNotFoundException;
 use PhpMqtt\Client\Exceptions\ProtocolNotSupportedException;
 use PhpMqtt\Client\Exceptions\ProtocolViolationException;
+use PhpMqtt\Client\MessageProcessors\Mqtt311MessageProcessor;
 use PhpMqtt\Client\MessageProcessors\Mqtt31MessageProcessor;
 use PhpMqtt\Client\Repositories\MemoryRepository;
 use Psr\Log\LoggerInterface;
@@ -35,6 +36,7 @@ class MqttClient implements ClientContract
         ValidatesConfiguration;
 
     const MQTT_3_1 = '3.1';
+    const MQTT_3_1_1 = '3.1.1';
 
     const QOS_AT_MOST_ONCE  = 0;
     const QOS_AT_LEAST_ONCE = 1;
@@ -95,6 +97,9 @@ class MqttClient implements ClientContract
         $this->logger     = new Logger($this->host, $this->port, $this->clientId, $logger);
 
         switch ($protocol) {
+            case self::MQTT_3_1_1:
+                $this->messageProcessor = new Mqtt311MessageProcessor($this->clientId, $this->logger);
+
             case self::MQTT_3_1:
             default:
                 $this->messageProcessor = new Mqtt31MessageProcessor($this->clientId, $this->logger);

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -808,7 +808,7 @@ class MqttClient implements ClientContract
                 // Starting from MQTT 3.1.1, the broker is able to reject individual subscriptions.
                 // Instead of failing the whole bulk, we log the incident and skip the single subscription.
                 if ($qualityOfService === 128) {
-                    $this->logger->error('The broker rejected the subscription to [{topicFilter}].', [
+                    $this->logger->notice('The broker rejected the subscription to [{topicFilter}].', [
                         'topicFilter' => $acknowledgedSubscriptions[$index]->getTopicFilter(),
                     ]);
                     continue;

--- a/tests/Feature/ConnectWithCustomConnectionSettingsTest.php
+++ b/tests/Feature/ConnectWithCustomConnectionSettingsTest.php
@@ -17,9 +17,41 @@ use Tests\TestCase;
  */
 class ConnectWithCustomConnectionSettingsTest extends TestCase
 {
-    public function test_connecting_with_custom_connection_settings_works_as_intended(): void
+    public function test_connecting_using_mqtt31_with_custom_connection_settings_works_as_intended(): void
     {
-        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-custom-connection-settings');
+        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-custom-connection-settings', MqttClient::MQTT_3_1);
+
+        $connectionSettings = (new ConnectionSettings)
+            ->setLastWillTopic('foo/last/will')
+            ->setLastWillMessage('baz is out!')
+            ->setLastWillQualityOfService(MqttClient::QOS_AT_MOST_ONCE)
+            ->setRetainLastWill(true)
+            ->setConnectTimeout(3)
+            ->setSocketTimeout(3)
+            ->setResendTimeout(3)
+            ->setKeepAliveInterval(30)
+            ->setUsername(null)
+            ->setPassword(null)
+            ->setUseTls(false)
+            ->setTlsCertificateAuthorityFile(null)
+            ->setTlsCertificateAuthorityPath(null)
+            ->setTlsClientCertificateFile(null)
+            ->setTlsClientCertificateKeyFile(null)
+            ->setTlsClientCertificateKeyPassphrase(null)
+            ->setTlsVerifyPeer(false)
+            ->setTlsVerifyPeerName(false)
+            ->setTlsSelfSignedAllowed(true);
+
+        $client->connect($connectionSettings);
+
+        $this->assertTrue($client->isConnected());
+
+        $client->disconnect();
+    }
+
+    public function test_connecting_using_mqtt311_with_custom_connection_settings_works_as_intended(): void
+    {
+        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-custom-connection-settings', MqttClient::MQTT_3_1_1);
 
         $connectionSettings = (new ConnectionSettings)
             ->setLastWillTopic('foo/last/will')

--- a/tests/Feature/SupportedProtocolsTest.php
+++ b/tests/Feature/SupportedProtocolsTest.php
@@ -24,18 +24,18 @@ class SupportedProtocolsTest extends TestCase
         $this->assertInstanceOf(MqttClient::class, $client);
     }
 
+    public function test_client_supports_mqtt_3_1_1_protocol(): void
+    {
+        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-protocol', MqttClient::MQTT_3_1_1);
+
+        $this->assertInstanceOf(MqttClient::class, $client);
+    }
+
     public function test_client_does_not_support_mqtt_3_protocol(): void
     {
         $this->expectException(ProtocolNotSupportedException::class);
 
         new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-protocol', '3');
-    }
-
-    public function test_client_does_not_support_mqtt_3_1_1_protocol(): void
-    {
-        $this->expectException(ProtocolNotSupportedException::class);
-
-        new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-protocol', '3.1.1');
     }
 
     public function test_client_does_not_support_mqtt_5_protocol(): void

--- a/tests/Unit/MessageProcessors/Mqtt311MessageProcessorTest.php
+++ b/tests/Unit/MessageProcessors/Mqtt311MessageProcessorTest.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MessageProcessors;
+
+use PhpMqtt\Client\ConnectionSettings;
+use PhpMqtt\Client\Logger;
+use PhpMqtt\Client\Subscription;
+use PhpMqtt\Client\MessageProcessors\Mqtt311MessageProcessor;
+use PHPUnit\Framework\TestCase;
+
+class Mqtt311MessageProcessorTest extends TestCase
+{
+    const CLIENT_ID = 'test-client';
+
+    /** @var Mqtt311MessageProcessor */
+    protected $messageProcessor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->messageProcessor = new Mqtt311MessageProcessor('test-client', new Logger('test.local', 1883, self::CLIENT_ID));
+    }
+
+    public function tryFindMessageInBuffer_testDataProvider(): array
+    {
+        return [
+            // No message and/or no knowledge about the remaining length of the message.
+            [hex2bin(''), false, null, null],
+            [hex2bin('20'), false, null, null],
+
+            // Incomplete message with knowledge about the remaining length of the message.
+            [hex2bin('2002'), false, null, 4],
+            [hex2bin('200200'), false, null, 4],
+
+            // Buffer contains only one complete message.
+            [hex2bin('20020000'), true, hex2bin('20020000'), null],
+            [hex2bin('800a0a03612f6201632f6402'), true, hex2bin('800a0a03612f6201632f6402'), null],
+
+            // Buffer contains more than one complete message.
+            [hex2bin('2002000044'), true, hex2bin('20020000'), null],
+            [hex2bin('4002000044'), true, hex2bin('40020000'), null],
+            [hex2bin('400200004412345678'), true, hex2bin('40020000'), null],
+        ];
+    }
+
+    /**
+     * @dataProvider tryFindMessageInBuffer_testDataProvider
+     *
+     * @param string      $buffer
+     * @param bool        $expectedResult
+     * @param string|null $expectedMessage
+     * @param int|null    $expectedRequiredBytes
+     */
+    public function test_tryFindMessageInBuffer_finds_messages_correctly(
+        string $buffer,
+        bool $expectedResult,
+        ?string $expectedMessage,
+        ?int $expectedRequiredBytes
+    ): void
+    {
+        $message       = null;
+        $requiredBytes = -1;
+
+        $result = $this->messageProcessor->tryFindMessageInBuffer($buffer, strlen($buffer), $message, $requiredBytes);
+
+        $this->assertEquals($expectedResult, $result);
+        $this->assertEquals($expectedMessage, $message);
+        if ($expectedRequiredBytes !== null) {
+            $this->assertEquals($expectedRequiredBytes, $requiredBytes);
+        } else {
+            $this->assertEquals(-1, $requiredBytes);
+        }
+    }
+
+    /**
+     * Message format:
+     *
+     *   <fixed header><protocol name><protocol version><flags><keep alive><client id><will topic><will message><username><password>
+     *
+     * @return array[]
+     * @throws \Exception
+     */
+    public function buildConnectMessage_testDataProvider(): array
+    {
+        return [
+            // Default parameters
+            [new ConnectionSettings(), false, hex2bin('101700044d5154540400000a000b') . self::CLIENT_ID],
+
+            // Clean Session
+            [new ConnectionSettings(), true, hex2bin('101700044d5154540402000a000b') . self::CLIENT_ID],
+
+            // Username, Password and Clean Session
+            [
+                (new ConnectionSettings())
+                    ->setUsername('foo')
+                    ->setPassword('bar'),
+                true,
+                hex2bin('102100044d51545404c2000a000b') . self::CLIENT_ID . hex2bin('0003') . 'foo' . hex2bin('0003') . 'bar',
+            ],
+
+            // Last Will Topic, Last Will Message and Clean Session
+            [
+                (new ConnectionSettings())
+                    ->setLastWillTopic('test/foo')
+                    ->setLastWillMessage('bar')
+                    ->setLastWillQualityOfService(1),
+                true,
+                hex2bin('102600044d515454040e000a000b') . self::CLIENT_ID . hex2bin('0008') . 'test/foo' . hex2bin('0003') . 'bar',
+            ],
+
+            // Last Will Topic, Last Will Message, Retain Last Will, Username, Password and Clean Session
+            [
+                (new ConnectionSettings())
+                    ->setLastWillTopic('test/foo')
+                    ->setLastWillMessage('bar')
+                    ->setLastWillQualityOfService(2)
+                    ->setRetainLastWill(true)
+                    ->setUsername('blub')
+                    ->setPassword('blubber'),
+                true,
+                hex2bin('103500044d51545404f6000a000b') . self::CLIENT_ID . hex2bin('0008') . 'test/foo' . hex2bin('0003') . 'bar'
+                    . hex2bin('0004') . 'blub' . hex2bin('0007') . 'blubber',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider buildConnectMessage_testDataProvider
+     *
+     * @param ConnectionSettings $connectionSettings
+     * @param bool               $useCleanSession
+     * @param string             $expectedResult
+     */
+    public function test_buildConnectMessage_builds_correct_message(
+        ConnectionSettings $connectionSettings,
+        bool $useCleanSession,
+        string $expectedResult
+    ): void
+    {
+        $result = $this->messageProcessor->buildConnectMessage($connectionSettings, $useCleanSession);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * Message format:
+     *
+     *   <fixed header><message id><topic><QoS>
+     *
+     * @return array[]
+     * @throws \Exception
+     */
+    public function buildSubscribeMessage_testDataProvider(): array
+    {
+        $longTopic = random_bytes(130);
+
+        return [
+            // Simple QoS 0 subscription
+            [42, [new Subscription('test/foo', 0)], hex2bin('82'.'0d00'.'2a00'.'08') . 'test/foo' . hex2bin('00')],
+
+            // Wildcard QoS 2 subscription with high message id
+            [43764, [new Subscription('test/foo/bar/baz/#', 2)], hex2bin('82'.'17aa'.'f400'.'12') . 'test/foo/bar/baz/#' . hex2bin('02')],
+
+            // Long QoS 1 subscription with high message id
+            [62304, [new Subscription($longTopic, 1)], hex2bin('82'.'8701'.'f360'.'0082') . $longTopic . hex2bin('01')],
+        ];
+    }
+
+    /**
+     * @dataProvider buildSubscribeMessage_testDataProvider
+     *
+     * @param int            $messageId
+     * @param Subscription[] $subscriptions
+     * @param string         $expectedResult
+     */
+    public function test_buildSubscribeMessage_builds_correct_message(
+        int $messageId,
+        array $subscriptions,
+        string $expectedResult
+    ): void
+    {
+        $result = $this->messageProcessor->buildSubscribeMessage($messageId, $subscriptions);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * Message format:
+     *
+     *   <fixed header><message id><topic>
+     *
+     * @return array[]
+     * @throws \Exception
+     */
+    public function buildUnsubscribeMessage_testDataProvider(): array
+    {
+        $longTopic = random_bytes(130);
+
+        return [
+            // Simple unsubscribe without duplicate
+            [42, ['test/foo'], false, hex2bin('a2'.'0c00'.'2a00'.'08') . 'test/foo'],
+
+            // Wildcard unsubscribe with high message id as duplicate
+            [43764, ['test/foo/bar/baz/#'], true, hex2bin('aa'.'16aa'.'f400'.'12') . 'test/foo/bar/baz/#'],
+
+            // Long unsubscribe with high message id as duplicate
+            [62304, [$longTopic], true, hex2bin('aa'.'8601'.'f360'.'0082') . $longTopic],
+        ];
+    }
+
+    /**
+     * @dataProvider buildUnsubscribeMessage_testDataProvider
+     *
+     * @param int      $messageId
+     * @param string[] $topics
+     * @param bool     $isDuplicate
+     * @param string   $expectedResult
+     */
+    public function test_buildUnsubscribeMessage_builds_correct_message(
+        int $messageId,
+        array $topics,
+        bool $isDuplicate,
+        string $expectedResult
+    ): void
+    {
+        $result = $this->messageProcessor->buildUnsubscribeMessage($messageId, $topics, $isDuplicate);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * Message format:
+     *
+     *   <fixed header><topic><message id><payload>
+     *
+     * @return array[]
+     * @throws \Exception
+     */
+    public function buildPublishMessage_testDataProvider(): array
+    {
+        $longMessage = random_bytes(424242);
+
+        return [
+            // Simple QoS 0 publish
+            ['test/foo', 'hello world', 0, false, 42, false, hex2bin('30'.'17'.'0008') . 'test/foo' . hex2bin('002a') . 'hello world'],
+
+            // Retained duplicate QoS 2 publish with long data and high message id
+            ['test/foo', $longMessage, 2, true, 4242, true, hex2bin('3d'.'bef219'.'0008') . 'test/foo' . hex2bin('1092') . $longMessage],
+        ];
+    }
+
+    /**
+     * @dataProvider buildPublishMessage_testDataProvider
+     *
+     * @param string $topic
+     * @param string $message
+     * @param int    $qualityOfService
+     * @param bool   $retain
+     * @param int    $messageId
+     * @param bool   $isDuplicate
+     * @param string $expectedResult
+     */
+    public function test_buildPublishMessage_builds_correct_message(
+        string $topic,
+        string $message,
+        int $qualityOfService,
+        bool $retain,
+        int $messageId,
+        bool $isDuplicate,
+        string $expectedResult
+    ): void
+    {
+        $result = $this->messageProcessor->buildPublishMessage(
+            $topic,
+            $message,
+            $qualityOfService,
+            $retain,
+            $messageId,
+            $isDuplicate
+        );
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * Message format:
+     *
+     *   <fixed header><message id>
+     *
+     * @return array[]
+     * @throws \Exception
+     */
+    public function buildPublishAcknowledgementMessage_testDataProvider(): array
+    {
+        return [
+            // Simple acknowledgement using small message id
+            [42, hex2bin('40'.'02'.'002a')],
+
+            // Simple acknowledgement using large message id
+            [4242, hex2bin('40'.'02'.'1092')],
+        ];
+    }
+
+    /**
+     * @dataProvider buildPublishAcknowledgementMessage_testDataProvider
+     *
+     * @param int    $messageId
+     * @param string $expectedResult
+     */
+    public function test_buildPublishAcknowledgementMessage_builds_correct_message(int $messageId, string $expectedResult): void
+    {
+        $result = $this->messageProcessor->buildPublishAcknowledgementMessage($messageId);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * Message format:
+     *
+     *   <fixed header><message id>
+     *
+     * @return array[]
+     * @throws \Exception
+     */
+    public function buildPublishReceivedMessage_testDataProvider(): array
+    {
+        return [
+            // Simple acknowledgement using small message id
+            [42, hex2bin('50'.'02'.'002a')],
+
+            // Simple acknowledgement using large message id
+            [4242, hex2bin('50'.'02'.'1092')],
+        ];
+    }
+
+    /**
+     * @dataProvider buildPublishReceivedMessage_testDataProvider
+     *
+     * @param int    $messageId
+     * @param string $expectedResult
+     */
+    public function test_buildPublishReceivedMessage_builds_correct_message(int $messageId, string $expectedResult): void
+    {
+        $result = $this->messageProcessor->buildPublishReceivedMessage($messageId);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * Message format:
+     *
+     *   <fixed header><message id>
+     *
+     * @return array[]
+     * @throws \Exception
+     */
+    public function buildPublishCompleteMessage_testDataProvider(): array
+    {
+        return [
+            // Simple acknowledgement using small message id
+            [42, hex2bin('70'.'02'.'002a')],
+
+            // Simple acknowledgement using large message id
+            [4242, hex2bin('70'.'02'.'1092')],
+        ];
+    }
+
+    /**
+     * @dataProvider buildPublishCompleteMessage_testDataProvider
+     *
+     * @param int    $messageId
+     * @param string $expectedResult
+     */
+    public function test_buildPublishCompleteMessage_builds_correct_message(int $messageId, string $expectedResult): void
+    {
+        $result = $this->messageProcessor->buildPublishCompleteMessage($messageId);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function test_buildPingMessage_builds_correct_message(): void
+    {
+        $this->assertEquals(hex2bin('c000'), $this->messageProcessor->buildPingRequestMessage());
+    }
+
+    public function test_buildDisconnectMessage_builds_correct_message(): void
+    {
+        $this->assertEquals(hex2bin('e000'), $this->messageProcessor->buildDisconnectMessage());
+    }
+}


### PR DESCRIPTION
This PR adds a second message processor which makes the client compatible with MQTT 3.1.1. The default implementation is still MQTT 3.1, which makes this addition fully backwards compatible. The relevant changes between MQTT 3.1 and MQTT 3.1.1 can be found [here](https://github.com/mqtt/mqtt.org/wiki/Differences-between-3.1.0-and-3.1.1).

Reviews are welcome. @thg2k @nicoworq