### PR TITLE
Add support for ^2.0 of psr/log

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --ignore-platform-reqs
+        run: composer install --prefer-dist
 
       - name: Generate certificates for tests
         run: sh create-certificates.sh

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": "^7.4|^8.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0",
         "myclabs/php-enum": "^1.7"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds support for `^2.0` of [`psr/log`](https://github.com/php-fig/log).

Support for v2 is fully backwards compatible and does not require any code changes, while support for v3 would require us to add return types to the [`Logger`](https://github.com/php-mqtt/client/blob/ddff90f65e73c872e43d1629aeb8028f7d2b3201/src/Logger.php) which is a breaking change and requires a major version bump.