### PR TITLE
Support for automatic reconnects

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ $connectionSettings = (new \PhpMqtt\Client\ConnectionSettings)
     // of pending messages without acknowledgement. The value cannot be less than 1 second.
     ->setResendTimeout(10)
     
+    // This flag determines whether the client will try to reconnect automatically
+    // if it notices a disconnect while sending data.
+    // The setting cannot be used together with the clean session flag.
+    ->setReconnectAutomatically(false)
+    
+    // Defines the maximum number of reconnect attempts until the client gives up.
+    // This setting is only relevant if setReconnectAutomatically() is set to true.
+    ->setMaxReconnectAttempts(3)
+    
     // The keep alive interval is the number of seconds the client will wait without sending a message
     // until it sends a keep alive signal (ping) to the broker. The value cannot be less than 1 second
     // and may not be higher than 65535 seconds. A reasonable value is 10 seconds (the default).

--- a/src/Concerns/ValidatesConfiguration.php
+++ b/src/Concerns/ValidatesConfiguration.php
@@ -43,6 +43,10 @@ trait ValidatesConfiguration
             throw new ConfigurationInvalidException('The keep alive interval must be a value in the range of 1 to 65535 seconds.');
         }
 
+        if ($settings->getMaxReconnectAttempts() < 1) {
+            throw new ConfigurationInvalidException('The maximum reconnect attempts cannot be fewer than 1.');
+        }
+
         if ($settings->getUsername() !== null && trim($settings->getUsername()) === '') {
             throw new ConfigurationInvalidException('The username may not consist of white space only.');
         }

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -17,6 +17,8 @@ class ConnectionSettings
     private int $socketTimeout                         = 5;
     private int $resendTimeout                         = 10;
     private int $keepAliveInterval                     = 10;
+    private bool $reconnectAutomatically               = false;
+    private int $maxReconnectAttempts                  = 3;
     private ?string $lastWillTopic                     = null;
     private ?string $lastWillMessage                   = null;
     private int $lastWillQualityOfService              = 0;
@@ -173,6 +175,55 @@ class ConnectionSettings
     public function getKeepAliveInterval(): int
     {
         return $this->keepAliveInterval;
+    }
+
+    /**
+     * This flag determines whether the client will try to reconnect automatically,
+     * if it notices a disconnect while sending data.
+     * The setting cannot be used together with the clean session flag.
+     *
+     * @param bool $reconnectAutomatically
+     * @return ConnectionSettings
+     */
+    public function setReconnectAutomatically(bool $reconnectAutomatically): ConnectionSettings
+    {
+        $copy = clone $this;
+
+        $copy->reconnectAutomatically = $reconnectAutomatically;
+
+        return $copy;
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldReconnectAutomatically(): bool
+    {
+        return $this->reconnectAutomatically;
+    }
+
+    /**
+     * Defines the maximum number of reconnect attempts until the client gives up. This setting
+     * is only relevant if {@see setReconnectAutomatically()} is set to true.
+     *
+     * @param int $maxReconnectAttempts
+     * @return ConnectionSettings
+     */
+    public function setMaxReconnectAttempts(int $maxReconnectAttempts): ConnectionSettings
+    {
+        $copy = clone $this;
+
+        $copy->maxReconnectAttempts = $maxReconnectAttempts;
+
+        return $copy;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxReconnectAttempts(): int
+    {
+        return $this->maxReconnectAttempts;
     }
 
     /**

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -31,15 +31,16 @@ use Psr\Log\LoggerInterface;
  */
 class MqttClient implements ClientContract
 {
-    use GeneratesRandomClientIds,
-        OffersHooks,
-        ValidatesConfiguration;
+    use GeneratesRandomClientIds;
+    use OffersHooks;
+    use ValidatesConfiguration;
 
     const MQTT_3_1 = '3.1';
 
-    const QOS_AT_MOST_ONCE  = 0;
-    const QOS_AT_LEAST_ONCE = 1;
-    const QOS_EXACTLY_ONCE  = 2;
+    const QOS_AT_MOST_ONCE        = 0;
+    const QOS_AT_LEAST_ONCE       = 1;
+    const QOS_EXACTLY_ONCE        = 2;
+    const SOCKET_READ_BUFFER_SIZE = 8192;
 
     private string $host;
     private int $port;
@@ -133,6 +134,18 @@ class MqttClient implements ClientContract
             $this->repository->reset();
         }
 
+        $this->connectInternal($useCleanSession);
+    }
+
+    /**
+     * Connect to the MQTT broker using the configured settings.
+     *
+     * @param bool $useCleanSession
+     * @return void
+     * @throws ConnectingToBrokerFailedException
+     */
+    protected function connectInternal(bool $useCleanSession = false): void
+    {
         try {
             $this->establishSocketConnection();
             $this->performConnectionHandshake($useCleanSession);
@@ -381,6 +394,28 @@ class MqttClient implements ClientContract
     }
 
     /**
+     * Attempts to reconnect to the broker. If a connection cannot be established within the configured number of retries,
+     * the last caught exception is thrown.
+     *
+     * @return void
+     * @throws ConnectingToBrokerFailedException
+     */
+    protected function reconnect(): void
+    {
+        $maxReconnectAttempts = $this->settings->getMaxReconnectAttempts();
+
+        for ($i = 1; $i <= $maxReconnectAttempts; $i++) {
+            try {
+                $this->connectInternal();
+            } catch (ConnectingToBrokerFailedException $e) {
+                if ($i === $maxReconnectAttempts) {
+                    throw $e;
+                }
+            }
+        }
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function interrupt(): void
@@ -525,7 +560,7 @@ class MqttClient implements ClientContract
 
         $data = $this->messageProcessor->buildPublishMessage($topic, $message, $qualityOfService, $retain, $messageId, $isDuplicate);
 
-        $this->writeToSocket($data);
+        $this->writeToSocketWithAutoReconnect($data);
     }
 
     /**
@@ -550,7 +585,7 @@ class MqttClient implements ClientContract
         $this->repository->addPendingOutgoingMessage($pendingMessage);
 
         $data = $this->messageProcessor->buildSubscribeMessage($messageId, $subscriptions);
-        $this->writeToSocket($data);
+        $this->writeToSocketWithAutoReconnect($data);
     }
 
     /**
@@ -569,7 +604,7 @@ class MqttClient implements ClientContract
         $this->repository->addPendingOutgoingMessage($pendingMessage);
 
         $data = $this->messageProcessor->buildUnsubscribeMessage($messageId, $topicFilters);
-        $this->writeToSocket($data);
+        $this->writeToSocketWithAutoReconnect($data);
     }
 
     /**
@@ -838,7 +873,7 @@ class MqttClient implements ClientContract
         // PINGREQ
         if ($message->getType()->equals(MessageType::PING_REQUEST())) {
             // Respond with PINGRESP.
-            $this->writeToSocket($this->messageProcessor->buildPingResponseMessage());
+            $this->writeToSocketWithAutoReconnect($this->messageProcessor->buildPingResponseMessage());
             return;
         }
     }
@@ -926,14 +961,14 @@ class MqttClient implements ClientContract
                 ]);
 
                 $data = $this->messageProcessor->buildSubscribeMessage($pendingMessage->getMessageId(), $pendingMessage->getSubscriptions(), true);
-                $this->writeToSocket($data);
+                $this->writeToSocketWithAutoReconnect($data);
             } elseif ($pendingMessage instanceof UnsubscribeRequest) {
                 $this->logger->debug('Re-sending pending unsubscribe request to the broker.', [
                     'messageId' => $pendingMessage->getMessageId(),
                 ]);
 
                 $data = $this->messageProcessor->buildUnsubscribeMessage($pendingMessage->getMessageId(), $pendingMessage->getTopicFilters(), true);
-                $this->writeToSocket($data);
+                $this->writeToSocketWithAutoReconnect($data);
             } else {
                 throw new InvalidMessageException('Unexpected message type encountered while resending pending messages.');
             }
@@ -954,7 +989,7 @@ class MqttClient implements ClientContract
     {
         $this->logger->debug('Sending publish acknowledgement to the broker (message id: {messageId}).', ['messageId' => $messageId]);
 
-        $this->writeToSocket($this->messageProcessor->buildPublishAcknowledgementMessage($messageId));
+        $this->writeToSocketWithAutoReconnect($this->messageProcessor->buildPublishAcknowledgementMessage($messageId));
     }
 
     /**
@@ -968,7 +1003,7 @@ class MqttClient implements ClientContract
     {
         $this->logger->debug('Sending publish received message to the broker (message id: {messageId}).', ['messageId' => $messageId]);
 
-        $this->writeToSocket($this->messageProcessor->buildPublishReceivedMessage($messageId));
+        $this->writeToSocketWithAutoReconnect($this->messageProcessor->buildPublishReceivedMessage($messageId));
     }
 
     /**
@@ -982,7 +1017,7 @@ class MqttClient implements ClientContract
     {
         $this->logger->debug('Sending publish release message to the broker (message id: {messageId}).', ['messageId' => $messageId]);
 
-        $this->writeToSocket($this->messageProcessor->buildPublishReleaseMessage($messageId));
+        $this->writeToSocketWithAutoReconnect($this->messageProcessor->buildPublishReleaseMessage($messageId));
     }
 
     /**
@@ -996,7 +1031,7 @@ class MqttClient implements ClientContract
     {
         $this->logger->debug('Sending publish complete message to the broker (message id: {messageId}).', ['messageId' => $messageId]);
 
-        $this->writeToSocket($this->messageProcessor->buildPublishCompleteMessage($messageId));
+        $this->writeToSocketWithAutoReconnect($this->messageProcessor->buildPublishCompleteMessage($messageId));
     }
 
     /**
@@ -1009,7 +1044,7 @@ class MqttClient implements ClientContract
     {
         $this->logger->debug('Sending ping to the broker to keep the connection alive.');
 
-        $this->writeToSocket($this->messageProcessor->buildPingRequestMessage());
+        $this->writeToSocketWithAutoReconnect($this->messageProcessor->buildPingRequestMessage());
     }
 
     /**
@@ -1024,12 +1059,45 @@ class MqttClient implements ClientContract
 
         $this->logger->debug('Sending disconnect package to the broker.');
 
-        $this->writeToSocket($data);
+        $this->writeToSocketWithAutoReconnect($data);
     }
 
     /**
-     * Writes some data to the socket. If a $length is given and it is shorter
-     * than the data, only $length amount of bytes will be sent.
+     * Writes some data to the socket. If a {@see $length} is given, and it is shorter
+     * than the data, only {@see $length} amount of bytes will be sent.
+     * If configured, this method will try to reconnect in case of transmission errors.
+     *
+     * @param string   $data
+     * @param int|null $length
+     * @return void
+     * @throws DataTransferException
+     */
+    protected function writeToSocketWithAutoReconnect(string $data, int $length = null): void
+    {
+        try {
+            $this->writeToSocket($data, $length);
+        } catch (DataTransferException $e) {
+            if (!$this->settings->shouldReconnectAutomatically()) {
+                throw $e;
+            }
+
+            try {
+                $this->reconnect();
+            } catch (ConnectingToBrokerFailedException $exception) {
+                $this->logger->error('Automatically reconnecting to the broker while writing data to the socket failed.');
+
+                // Throw the original exception.
+                throw $e;
+            }
+
+            // Retry writing to the socket. If this fails again, the exception is thrown as-is.
+            $this->writeToSocket($data, $length);
+        }
+    }
+
+    /**
+     * Writes some data to the socket. If a {@see $length} is given, and it is shorter
+     * than the data, only {@see $length} amount of bytes will be sent.
      *
      * @param string   $data
      * @param int|null $length
@@ -1061,16 +1129,50 @@ class MqttClient implements ClientContract
     }
 
     /**
-     * Reads data from the socket. If the second parameter $withoutBlocking is set to true,
-     * a maximum of $limit bytes will be read and returned. If $withoutBlocking is set to false,
-     * the method will wait until $limit bytes have been received.
+     * Reads data from the socket. If the second parameter {@see $withoutBlocking} is set to true,
+     * a maximum of {@see $limit} bytes will be read and returned. If {@see $withoutBlocking} is set to false,
+     * the method will wait until {@see $limit} bytes have been received.
+     * If configured, this method will try to reconnect in case of transmission errors.
      *
      * @param int  $limit
      * @param bool $withoutBlocking
      * @return string
      * @throws DataTransferException
      */
-    protected function readFromSocket(int $limit = 8192, bool $withoutBlocking = false): string
+    protected function readFromSocketWithAutoReconnect(int $limit = self::SOCKET_READ_BUFFER_SIZE, bool $withoutBlocking = false): string
+    {
+        try {
+            return $this->readFromSocket($limit, $withoutBlocking);
+        } catch (DataTransferException $e) {
+            if (!$this->settings->shouldReconnectAutomatically()) {
+                throw $e;
+            }
+
+            try {
+                $this->reconnect();
+            } catch (ConnectingToBrokerFailedException $exception) {
+                $this->logger->error('Automatically reconnecting to the broker while reading data from the socket failed.');
+
+                // Throw the original exception.
+                throw $e;
+            }
+
+            // Retry writing to the socket. If this fails again, the exception is thrown as-is.
+            return $this->readFromSocket($limit, $withoutBlocking);
+        }
+    }
+
+    /**
+     * Reads data from the socket. If the second parameter {@see $withoutBlocking} is set to true,
+     * a maximum of {@see $limit} bytes will be read and returned. If {@see $withoutBlocking} is set to false,
+     * the method will wait until {@see $limit} bytes have been received.
+     *
+     * @param int  $limit
+     * @param bool $withoutBlocking
+     * @return string
+     * @throws DataTransferException
+     */
+    protected function readFromSocket(int $limit = self::SOCKET_READ_BUFFER_SIZE, bool $withoutBlocking = false): string
     {
         if ($withoutBlocking) {
             $result = fread($this->socket, $limit);
@@ -1117,22 +1219,25 @@ class MqttClient implements ClientContract
 
     /**
      * Reads all the available data from the socket using non-blocking mode. Essentially this means
-     * that {@see MqttClient::readFromSocket()} is called over and over again, as long as data is
+     * that {@see MqttClient::readFromSocketWithAutoReconnect()} is called over and over again, as long as data is
      * returned.
      *
+     * @param bool $withAutoReconnectIfConfigured
      * @return string
      * @throws DataTransferException
      */
-    protected function readAllAvailableDataFromSocket(): string
+    protected function readAllAvailableDataFromSocket(bool $withAutoReconnectIfConfigured = false): string
     {
         $result = '';
 
         while (true) {
-            $buffer = $this->readFromSocket(8192, true);
+            $buffer = $withAutoReconnectIfConfigured
+                ? $this->readFromSocketWithAutoReconnect(self::SOCKET_READ_BUFFER_SIZE, true)
+                : $this->readFromSocket(self::SOCKET_READ_BUFFER_SIZE, true);
 
             $result .= $buffer;
 
-            if (strlen($buffer) < 8192) {
+            if (strlen($buffer) < self::SOCKET_READ_BUFFER_SIZE) {
                 break;
             }
         }

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -407,6 +407,8 @@ class MqttClient implements ClientContract
         for ($i = 1; $i <= $maxReconnectAttempts; $i++) {
             try {
                 $this->connectInternal();
+
+                return;
             } catch (ConnectingToBrokerFailedException $e) {
                 if ($i === $maxReconnectAttempts) {
                     throw $e;


### PR DESCRIPTION
As per the discussion in #104, this PR attempts to implement automatic reconnects. The implementation has this feature disabeld by default for backwards compatibility.

To simplify the code and avoid code duplication, `writeToSocket()` and `readFromSocket()` have been wrapped with the `writeToSocketWithAutoReconnect()` and `readFromSocketWithAutoReconnect()` counterparts. We also do not use auto-reconnect logic during connection handshakes to prevent recursion issues.

As of now, the PR lacks tests because it is quite difficult to have the broker disconnect the client on command. If anyone has an idea what logic could be used to force a disconnect server-side, I'd greatly appreciate it!