### PR TITLE
Add .github/release.yml for auto-changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Added
+      labels:
+        - enhancement
+    - title: Deprecated
+      labels:
+        - deprecated
+    - title: Removed
+      labels:
+        - removed
+    - title: Fixed
+      labels:
+        - bug
+    - title: Security
+      labels:
+        - security
+    - title: Changed
+      labels:
+        - "*"


### PR DESCRIPTION
GitHub supports auto-generating changelogs from pull requests based on labels (see [here](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes)). This PR enables this feature.