### PR TITLE
Run CI tests against Mosquitto 2.0

### DIFF
--- a/.ci/mosquitto.conf
+++ b/.ci/mosquitto.conf
@@ -13,6 +13,7 @@ cafile /mosquitto-certs/ca.crt
 certfile /mosquitto-certs/server.crt
 keyfile /mosquitto-certs/server.key
 require_certificate false
+allow_anonymous true
 
 # TLS listener with client certificate requirement
 listener 8884
@@ -20,3 +21,4 @@ cafile /mosquitto-certs/ca.crt
 certfile /mosquitto-certs/server.crt
 keyfile /mosquitto-certs/server.key
 require_certificate true
+allow_anonymous true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.4', '8.0', '8.1']
-        mqtt-broker: ['mosquitto', 'hivemq', 'emqx', 'rabbitmq']
+        mqtt-broker: ['mosquitto-1.6', 'mosquitto-2.0', 'hivemq', 'emqx', 'rabbitmq']
         include:
           - php-version: '8.1'
-            mqtt-broker: 'mosquitto'
+            mqtt-broker: 'mosquitto-2.0'
             run-sonarqube-analysis: true
 
     steps:
@@ -65,11 +65,20 @@ jobs:
       - name: Generate certificates for tests
         run: sh create-certificates.sh
 
-      - name: Start Mosquitto message broker
-        if: matrix.mqtt-broker == 'mosquitto'
+      - name: Start Mosquitto 1.6 message broker
+        if: matrix.mqtt-broker == 'mosquitto-1.6'
         uses: Namoshek/mosquitto-github-action@v1
         with:
           version: '1.6'
+          ports: '1883:1883 8883:8883 8884:8884'
+          certificates: ${{ github.workspace }}/.ci/tls
+          config: ${{ github.workspace }}/.ci/mosquitto.conf
+
+      - name: Start Mosquitto 2.0 message broker
+        if: matrix.mqtt-broker == 'mosquitto-2.0'
+        uses: Namoshek/mosquitto-github-action@v1
+        with:
+          version: '2.0'
           ports: '1883:1883 8883:8883 8884:8884'
           certificates: ${{ github.workspace }}/.ci/tls
           config: ${{ github.workspace }}/.ci/mosquitto.conf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,10 @@ jobs:
         run: composer install --prefer-dist
 
       - name: Generate certificates for tests
-        run: sh create-certificates.sh && chmod u+rx,g+rx ${{ github.workspace }}/.ci/tls
+        run: |
+          sh create-certificates.sh
+          chmod u+rx,g+rx ${{ github.workspace }}/.ci/tls
+          chmod a+r ${{ github.workspace }}/.ci/tls/*
 
       - name: Start Mosquitto 1.6 message broker
         if: matrix.mqtt-broker == 'mosquitto-1.6'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
         run: composer install --prefer-dist
 
       - name: Generate certificates for tests
-        run: sh create-certificates.sh
+        run: sh create-certificates.sh && chmod u+rx,g+rx ${{ github.workspace }}/.ci/tls
 
       - name: Start Mosquitto 1.6 message broker
         if: matrix.mqtt-broker == 'mosquitto-1.6'


### PR DESCRIPTION
Until now, the tests are only run against Mosquitto 1.6. In the mean time, Mosquitto 2.0 has been released (with quite a few patch versions already). Therefore, we also run the tests against Mosquitto 2.0 now.