### PR TITLE
Run some integration tests with authentication

### DIFF
--- a/.ci/mosquitto.conf
+++ b/.ci/mosquitto.conf
@@ -1,7 +1,14 @@
 # Config file for mosquitto
+per_listener_settings true
 
 # Port to use for the default listener.
-port 1883
+listener 1883
+allow_anonymous true
+
+# Port to use for the default listener with authentication.
+listener 1884
+password_file /mosquitto/config/mosquitto.passwd
+allow_anonymous false
 
 # =================================================================
 # Extra listeners

--- a/.ci/mosquitto.passwd
+++ b/.ci/mosquitto.passwd
@@ -1,1 +1,1 @@
-ci-test-user:$6$HbgpxSZS3v7CzCo1$hF/4U5jPi9QzV/HfaXXBWEDIvMfjRyiM2UZHbsGDArFi6g8o/POJEgX1EQkMM2JzOuBd+vYOjunOvGM/o/Db1g==
+ci-test-user:$6$QypQBNSQKE5bg6Ec$nzACfxhQ9qiYFByPPM/6GP/9kOWwDzEftN0EJPkS6M0PWqL55jAbBxUO863oWwhJ2q/YaubfLbe3xwwhBuoStQ==

--- a/.ci/mosquitto.passwd
+++ b/.ci/mosquitto.passwd
@@ -1,0 +1,1 @@
+ci-test-user:$6$HbgpxSZS3v7CzCo1$hF/4U5jPi9QzV/HfaXXBWEDIvMfjRyiM2UZHbsGDArFi6g8o/POJEgX1EQkMM2JzOuBd+vYOjunOvGM/o/Db1g==

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,8 +120,11 @@ jobs:
         env:
           MQTT_BROKER_HOST: 'localhost'
           MQTT_BROKER_PORT: 1883
+          MQTT_BROKER_PORT_WITH_AUTHENTICATION: 1884
           MQTT_BROKER_TLS_PORT: 8883
           MQTT_BROKER_TLS_WITH_CLIENT_CERT_PORT: 8884
+          MQTT_BROKER_USERNAME: ci-test-user
+          MQTT_BROKER_PASSWORD: ${{ secrets.CI_MOSQUITTO_CI_TEST_USER_PASSWORD }}
           SKIP_TLS_TESTS: ${{ matrix.mqtt-broker == 'emqx' || matrix.mqtt-broker == 'rabbitmq' }}
 
       - name: Dump Docker logs on failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,7 @@ jobs:
           ports: '1883:1883 1884:1884 8883:8883 8884:8884'
           certificates: ${{ github.workspace }}/.ci/tls
           config: ${{ github.workspace }}/.ci/mosquitto.conf
+          password-file: ${{ github.workspace}}/.ci/mosquitto.passwd
 
       - name: Start Mosquitto 2.0 message broker
         if: matrix.mqtt-broker == 'mosquitto-2.0'
@@ -85,6 +86,7 @@ jobs:
           ports: '1883:1883 1884:1884 8883:8883 8884:8884'
           certificates: ${{ github.workspace }}/.ci/tls
           config: ${{ github.workspace }}/.ci/mosquitto.conf
+          password-file: ${{ github.workspace}}/.ci/mosquitto.passwd
 
       - name: Start HiveMQ message broker
         if: matrix.mqtt-broker == 'hivemq'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
         uses: Namoshek/mosquitto-github-action@v1
         with:
           version: '1.6'
-          ports: '1883:1883 8883:8883 8884:8884'
+          ports: '1883:1883 1884:1884 8883:8883 8884:8884'
           certificates: ${{ github.workspace }}/.ci/tls
           config: ${{ github.workspace }}/.ci/mosquitto.conf
 
@@ -82,7 +82,7 @@ jobs:
         uses: Namoshek/mosquitto-github-action@v1
         with:
           version: '2.0'
-          ports: '1883:1883 8883:8883 8884:8884'
+          ports: '1883:1883 1884:1884 8883:8883 8884:8884'
           certificates: ${{ github.workspace }}/.ci/tls
           config: ${{ github.workspace }}/.ci/mosquitto.conf
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,11 +120,11 @@ jobs:
         env:
           MQTT_BROKER_HOST: 'localhost'
           MQTT_BROKER_PORT: 1883
-          MQTT_BROKER_PORT_WITH_AUTHENTICATION: 1884
+          MQTT_BROKER_PORT_WITH_AUTHENTICATION: ${{ (matrix.mqtt-broker == 'mosquitto-1.6' || matrix.mqtt-broker == 'mosquitto-2.0') && 1884 || 1883 }}
           MQTT_BROKER_TLS_PORT: 8883
           MQTT_BROKER_TLS_WITH_CLIENT_CERT_PORT: 8884
-          MQTT_BROKER_USERNAME: ci-test-user
-          MQTT_BROKER_PASSWORD: ${{ secrets.CI_MOSQUITTO_CI_TEST_USER_PASSWORD }}
+          MQTT_BROKER_USERNAME: ${{ (matrix.mqtt-broker == 'mosquitto-1.6' || matrix.mqtt-broker == 'mosquitto-2.0') && 'ci-test-user' || '' }}
+          MQTT_BROKER_PASSWORD: ${{ (matrix.mqtt-broker == 'mosquitto-1.6' || matrix.mqtt-broker == 'mosquitto-2.0') && secrets.CI_MOSQUITTO_CI_TEST_USER_PASSWORD || '' }}
           SKIP_TLS_TESTS: ${{ matrix.mqtt-broker == 'emqx' || matrix.mqtt-broker == 'rabbitmq' }}
 
       - name: Dump Docker logs on failure

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
     <php>
         <env name="MQTT_BROKER_HOST" value="localhost"/>
         <env name="MQTT_BROKER_PORT" value="1883"/>
+        <env name="MQTT_BROKER_PORT_WITH_AUTHENTICATION" value="1883"/>
         <env name="MQTT_BROKER_TLS_PORT" value="8883"/>
         <env name="MQTT_BROKER_TLS_WITH_CLIENT_CERT_PORT" value="8884"/>
         <env name="TLS_CERT_DIR" value=".ci/tls"/>

--- a/tests/Feature/ConnectWithCustomConnectionSettingsTest.php
+++ b/tests/Feature/ConnectWithCustomConnectionSettingsTest.php
@@ -19,7 +19,7 @@ class ConnectWithCustomConnectionSettingsTest extends TestCase
 {
     public function test_connecting_using_mqtt31_with_custom_connection_settings_works_as_intended(): void
     {
-        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-custom-connection-settings', MqttClient::MQTT_3_1);
+        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPortWithAuthentication, 'test-custom-connection-settings', MqttClient::MQTT_3_1);
 
         $connectionSettings = (new ConnectionSettings)
             ->setLastWillTopic('foo/last/will')
@@ -30,8 +30,8 @@ class ConnectWithCustomConnectionSettingsTest extends TestCase
             ->setSocketTimeout(3)
             ->setResendTimeout(3)
             ->setKeepAliveInterval(30)
-            ->setUsername(null)
-            ->setPassword(null)
+            ->setUsername($this->mqttBrokerUsername)
+            ->setPassword($this->mqttBrokerPassword)
             ->setUseTls(false)
             ->setTlsCertificateAuthorityFile(null)
             ->setTlsCertificateAuthorityPath(null)
@@ -51,7 +51,7 @@ class ConnectWithCustomConnectionSettingsTest extends TestCase
 
     public function test_connecting_using_mqtt311_with_custom_connection_settings_works_as_intended(): void
     {
-        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-custom-connection-settings', MqttClient::MQTT_3_1_1);
+        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPortWithAuthentication, 'test-custom-connection-settings', MqttClient::MQTT_3_1_1);
 
         $connectionSettings = (new ConnectionSettings)
             ->setLastWillTopic('foo/last/will')
@@ -62,8 +62,8 @@ class ConnectWithCustomConnectionSettingsTest extends TestCase
             ->setSocketTimeout(3)
             ->setResendTimeout(3)
             ->setKeepAliveInterval(30)
-            ->setUsername(null)
-            ->setPassword(null)
+            ->setUsername($this->mqttBrokerUsername)
+            ->setPassword($this->mqttBrokerPassword)
             ->setUseTls(false)
             ->setTlsCertificateAuthorityFile(null)
             ->setTlsCertificateAuthorityPath(null)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,8 +13,12 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     protected string $mqttBrokerHost;
     protected int $mqttBrokerPort;
+    protected int $mqttBrokerPortWithAuthentication;
     protected int $mqttBrokerTlsPort;
     protected int $mqttBrokerTlsWithClientCertificatePort;
+
+    protected ?string $mqttBrokerUsername = null;
+    protected ?string $mqttBrokerPassword = null;
 
     protected bool $skipTlsTests;
     protected string $tlsCertificateDirectory;
@@ -28,8 +32,12 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
         $this->mqttBrokerHost                         = getenv('MQTT_BROKER_HOST');
         $this->mqttBrokerPort                         = intval(getenv('MQTT_BROKER_PORT'));
+        $this->mqttBrokerPortWithAuthentication       = intval(getenv('MQTT_BROKER_PORT_WITH_AUTHENTICATION'));
         $this->mqttBrokerTlsPort                      = intval(getenv('MQTT_BROKER_TLS_PORT'));
         $this->mqttBrokerTlsWithClientCertificatePort = intval(getenv('MQTT_BROKER_TLS_WITH_CLIENT_CERT_PORT'));
+
+        $this->mqttBrokerUsername                     = getenv('MQTT_BROKER_USERNAME') ?: null;
+        $this->mqttBrokerPassword                     = getenv('MQTT_BROKER_PASSWORD') ?: null;
 
         $this->skipTlsTests            = getenv('SKIP_TLS_TESTS') === 'true';
         $this->tlsCertificateDirectory = rtrim(getenv('TLS_CERT_DIR'), '/');


### PR DESCRIPTION
As there have been multiple reports in #105 about failing logins to Mosquitto after upgrading to Mosquitto 2, this PR adds integration tests to the build pipeline which ensure authentication works as expected with Mosquitto.

To achieve this, Mosquitto listenes on an additional port `1884` with enabled authentication whitelist (and disabled anonymous authentication). The pipeline uses a static hashed passwd file for the `ci-test-user`.