### PR TITLE
Fix: Local test setup uses port 1884 for MQTT with authentication

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
           plugins: 'rabbitmq_mqtt'
 
       - name: Wait a bit until MQTT broker has started
-        run: sleep 45
+        run: sleep 60
 
       - name: Run phpunit tests
         run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
         if: matrix.mqtt-broker == 'hivemq'
         uses: Namoshek/hivemq4-github-action@v1
         with:
-          version: '4.4.4'
+          version: '4.8.5'
           ports: '1883:1883 8883:8883 8884:8884'
           certificates: ${{ github.workspace }}/.ci/tls
           config: ${{ github.workspace }}/.ci/hivemq.xml
@@ -115,7 +115,7 @@ jobs:
           plugins: 'rabbitmq_mqtt'
 
       - name: Wait a bit until MQTT broker has started
-        run: sleep 60
+        run: sleep 45
 
       - name: Run phpunit tests
         run: composer test

--- a/README.md
+++ b/README.md
@@ -284,7 +284,15 @@ This will create all required certificates in the `.ci/tls/` directory. The same
 
 Running the tests expects an MQTT broker to be running. The easiest way to run an MQTT broker is through Docker:
 ```sh
-docker run --rm -it -p 1883:1883 -p 8883:8883 -p 8884:8884 -v $(pwd)/.ci/tls:/mosquitto-certs -v $(pwd)/.ci/mosquitto.conf:/mosquitto/config/mosquitto.conf eclipse-mosquitto:1.6
+docker run --rm -it \
+  -p 1883:1883 \
+  -p 1884:1884 \
+  -p 8883:8883 \
+  -p 8884:8884 \
+  -v $(pwd)/.ci/tls:/mosquitto-certs \
+  -v $(pwd)/.ci/mosquitto.conf:/mosquitto/config/mosquitto.conf \
+  -v $(pwd)/.ci/mosquitto.passwd:/mosquitto/config/mosquitto.passwd \
+  eclipse-mosquitto:1.6
 ```
 When run from the project directory, this will spawn a Mosquitto MQTT broker configured with the generated TLS certificates and a custom configuration.
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
     <php>
         <env name="MQTT_BROKER_HOST" value="localhost"/>
         <env name="MQTT_BROKER_PORT" value="1883"/>
-        <env name="MQTT_BROKER_PORT_WITH_AUTHENTICATION" value="1883"/>
+        <env name="MQTT_BROKER_PORT_WITH_AUTHENTICATION" value="1884"/>
         <env name="MQTT_BROKER_TLS_PORT" value="8883"/>
         <env name="MQTT_BROKER_TLS_WITH_CLIENT_CERT_PORT" value="8884"/>
         <env name="TLS_CERT_DIR" value=".ci/tls"/>


### PR DESCRIPTION
This PR changes the port for MQTT with authentication used in `phpunit.xml`. It also updates the example command to run a local dev Mosquitto in the `README.md`.

Also does this PR change the version of HiveMQ we test in our CI build against to `v4.8.5` because the Java Key Store (JKS) we create in `create-certificates.sh` is being built with a never Java version and therefore the JKS cannot be read by HiveMQ `v4.4.4`.