### PR TITLE
Pass matched topic wildcards to subscription callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $clientId = 'test-subscriber';
 
 $mqtt = new \PhpMqtt\Client\MqttClient($server, $port, $clientId);
 $mqtt->connect();
-$mqtt->subscribe('php-mqtt/client/test', function ($topic, $message) {
+$mqtt->subscribe('php-mqtt/client/test', function ($topic, $message, $retained, $matchedWildcards) {
     echo sprintf("Received message on topic [%s]: %s\n", $topic, $message);
 }, 0);
 $mqtt->loop(true);
@@ -80,7 +80,7 @@ pcntl_signal(SIGINT, function (int $signal, $info) use ($mqtt) {
     $mqtt->interrupt();
 });
 $mqtt->connect();
-$mqtt->subscribe('php-mqtt/client/test', function ($topic, $message) {
+$mqtt->subscribe('php-mqtt/client/test', function ($topic, $message, $retained, $matchedWildcards) {
     echo sprintf("Received message on topic [%s]: %s\n", $topic, $message);
 }, 0);
 $mqtt->loop(true);

--- a/src/Contracts/MqttClient.php
+++ b/src/Contracts/MqttClient.php
@@ -76,13 +76,13 @@ interface MqttClient
      *
      * The subscription callback is passed the topic as first and the message as second
      * parameter. A third parameter indicates whether the received message has been sent
-     * because it was retained by the broker.
+     * because it was retained by the broker. A fourth parameter contains matched topic wildcards.
      *
      * Example:
      * ```php
      * $mqtt->subscribe(
      *     '/foo/bar/+',
-     *     function (string $topic, string $message, bool $retained) use ($logger) {
+     *     function (string $topic, string $message, bool $retained, array $matchedWildcards) use ($logger) {
      *         $logger->info("Received {retained} message on topic [{topic}]: {message}", [
      *             'topic' => $topic,
      *             'message' => $message,

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -941,7 +941,7 @@ class MqttClient implements ClientContract
             }
 
             try {
-                call_user_func($subscriber->getCallback(), $topic, $message, $retained);
+                call_user_func($subscriber->getCallback(), $topic, $message, $retained, $subscriber->getMatchedWildcards($topic));
             } catch (\Throwable $e) {
                 $this->logger->error('Subscriber callback threw exception for published message on topic [{topic}].', [
                     'topic' => $topic,

--- a/src/Repositories/MemoryRepository.php
+++ b/src/Repositories/MemoryRepository.php
@@ -202,7 +202,7 @@ class MemoryRepository implements Repository
         $result = [];
 
         foreach ($this->subscriptions as $subscription) {
-            if ($topicName !== null && !$subscription->matchesTopic($topicName)) {
+            if (!$subscription->matchesTopic($topicName)) {
                 continue;
             }
 


### PR DESCRIPTION
This PR introduces a new feature for subscriptions made on a wildcard topic. All matched wildcard parts of the topic are now extracted and passed to the subscription callback. This is best explained with an example:
```
Subscription made on topic pattern 'foo/bar/+'
Message received for topic 'foo/bar/baz'
The matched wildcard topic levels are passed to the subscription callback: ['baz']

Subscription made on topic pattern 'foo/+/bar/#'
Message received for topic 'foo/baz/bar/hello/world'
The matched wildcard topic levels are passed to the subscription callback: ['baz', 'hello/world']
```

The matched wildcards are passed as fourth parameter to the subscription callback:
```php
$mqtt->subscribe('foo/+/bar/#', function ($topic, $message, $retained, $matchedWildcards) {
    echo sprintf("Received message on topic [%s]: %s\n", $topic, $message);
}, 0);
```