### PR TITLE
Add new connection setting for delay between reconnect attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ $connectionSettings = (new \PhpMqtt\Client\ConnectionSettings)
     // This setting is only relevant if setReconnectAutomatically() is set to true.
     ->setMaxReconnectAttempts(3)
     
+    // Defines the delay between reconnect attempts in milliseconds.
+    // This setting is only relevant if setReconnectAutomatically() is set to true.
+    ->setDelayBetweenReconnectAttempts(0)
+    
     // The keep alive interval is the number of seconds the client will wait without sending a message
     // until it sends a keep alive signal (ping) to the broker. The value cannot be less than 1 second
     // and may not be higher than 65535 seconds. A reasonable value is 10 seconds (the default).

--- a/src/Concerns/ValidatesConfiguration.php
+++ b/src/Concerns/ValidatesConfiguration.php
@@ -47,6 +47,10 @@ trait ValidatesConfiguration
             throw new ConfigurationInvalidException('The maximum reconnect attempts cannot be fewer than 1.');
         }
 
+        if ($settings->getDelayBetweenReconnectAttempts() < 0) {
+            throw new ConfigurationInvalidException('The delay between reconnect attempts cannot be lower than 0.');
+        }
+
         if ($settings->getUsername() !== null && trim($settings->getUsername()) === '') {
             throw new ConfigurationInvalidException('The username may not consist of white space only.');
         }

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -19,6 +19,7 @@ class ConnectionSettings
     private int $keepAliveInterval                     = 10;
     private bool $reconnectAutomatically               = false;
     private int $maxReconnectAttempts                  = 3;
+    private int $delayBetweenReconnectAttempts         = 0;
     private ?string $lastWillTopic                     = null;
     private ?string $lastWillMessage                   = null;
     private int $lastWillQualityOfService              = 0;
@@ -224,6 +225,30 @@ class ConnectionSettings
     public function getMaxReconnectAttempts(): int
     {
         return $this->maxReconnectAttempts;
+    }
+
+    /**
+     * Defines the delay between reconnect attempts in milliseconds.
+     * This setting is only relevant if {@see setReconnectAutomatically()} is set to true.
+     *
+     * @param int $delayBetweenReconnectAttempts
+     * @return ConnectionSettings
+     */
+    public function setDelayBetweenReconnectAttempts(int $delayBetweenReconnectAttempts): ConnectionSettings
+    {
+        $copy = clone $this;
+
+        $copy->delayBetweenReconnectAttempts = $delayBetweenReconnectAttempts;
+
+        return $copy;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDelayBetweenReconnectAttempts(): int
+    {
+        return $this->delayBetweenReconnectAttempts;
     }
 
     /**

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -409,7 +409,8 @@ class MqttClient implements ClientContract
      */
     protected function reconnect(): void
     {
-        $maxReconnectAttempts = $this->settings->getMaxReconnectAttempts();
+        $maxReconnectAttempts          = $this->settings->getMaxReconnectAttempts();
+        $delayBetweenReconnectAttempts = $this->settings->getDelayBetweenReconnectAttempts();
 
         for ($i = 1; $i <= $maxReconnectAttempts; $i++) {
             try {
@@ -419,6 +420,10 @@ class MqttClient implements ClientContract
             } catch (ConnectingToBrokerFailedException $e) {
                 if ($i === $maxReconnectAttempts) {
                     throw $e;
+                }
+
+                if ($delayBetweenReconnectAttempts > 0) {
+                    usleep($delayBetweenReconnectAttempts * 1000);
                 }
             }
         }


### PR DESCRIPTION
As discussed in #129, the auto-reconnect feature only offers basic functionality as of right now. This PR therefore adds an additional connection setting for the delay between reconnect attempts `setDelayBetweenReconnectAttempts($delay)` which can be used in combination with `setReconnectAutomatically(true)` and `setMaxReconnectAttempts($attempts)`:
```php
$connectionSettings = (new \PhpMqtt\Client\ConnectionSettings)
    ->setReconnectAutomatically(true)
    ->setMaxReconnectAttempts(3)
    ->setDelayBetweenReconnectAttempts(0);
```

---

✔️ For backwards compatibility, the default delay between reconnect attempts is zero.
✔️ Integration tests for the auto-reconnect feature do not exist and are almost impossible to write, therefore this PR does not contain any tests. Manual tests have been performed.

⚠️ The `setDelayBetweenReconnectAttempts($delay)` accepts a `$delay` in milliseconds, which is different to other (timeout) settings.
⚠️ Whether setting a delay between reconnect attempts makes sense, is up to the user of this library. In some scenarios, there is already some kind of delay given in the form of the connect timeout.
