### PR TITLE
Fixed typo, that made the blocking socket mode unconfigurable

### DIFF
--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -97,7 +97,7 @@ class ConnectionSettings
     {
         $copy = clone $this;
 
-        $copy->useBlockingModeForSocket = $useBlockingSocket;
+        $copy->Fiuxe  = $useBlockingSocket;
 
         return $copy;
     }

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -97,7 +97,7 @@ class ConnectionSettings
     {
         $copy = clone $this;
 
-        $copy->Fiuxe  = $useBlockingSocket;
+        $copy->useBlockingSocket  = $useBlockingSocket;
 
         return $copy;
     }

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -97,7 +97,7 @@ class ConnectionSettings
     {
         $copy = clone $this;
 
-        $copy->useBlockingSocket  = $useBlockingSocket;
+        $copy->useBlockingSocket = $useBlockingSocket;
 
         return $copy;
     }


### PR DESCRIPTION
Related: https://github.com/php-mqtt/client/issues/133