### PR TITLE
Use pull_request_target trigger in test pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
Other than the pull_request trigger, the pull_request_target runs against the workflow version of the target branch and grants the workflow access to secrets, which we need in our test runs.