### PR TITLE
Fix: Use blocking socket only during publishing if configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,11 @@ $connectionSettings = (new \PhpMqtt\Client\ConnectionSettings)
     // The password used for authentication when connecting to the broker.
     ->setPassword(null)
     
-    // Whether to use a blocking socket or not. By default, the socket is non-blocking,
-    // which is required when using subscriptions and/or {@see MqttClient::loop()}.
-    // In rare cases, it might be required to use a blocking socket though. One such example
-    // is when sending large messages (e.g. binaries) and the broker has a limited receive buffer.
-    // 
-    // Note: When using a blocking socket, the MQTT client can get stuck if the socket is broken
-    //       or when the broker does not consume the sent data fast enough. Use with caution.
+    // Whether to use a blocking socket when publishing messages or not.
+    // Normally, this setting can be ignored. When publishing large messages with multiple kilobytes in size,
+    // a blocking socket may be required if the receipt buffer of the broker is not large enough.
+    //
+    // Note: This setting has no effect on subscriptions, only on the publishing of messages.
     ->useBlockingSocket(false)
     
     // The connect timeout defines the maximum amount of seconds the client will try to establish

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -82,13 +82,11 @@ class ConnectionSettings
     }
 
     /**
-     * Whether to use a blocking socket or not. By default, the socket is non-blocking,
-     * which is required when using subscriptions and/or {@see MqttClient::loop()}.
-     * In rare cases, it might be required to use a blocking socket though. One such example
-     * is when sending large messages (e.g. binaries) and the broker has a limited receive buffer.
+     * Whether to use a blocking socket when publishing messages or not.
+     * Normally, this setting can be ignored. When publishing large messages with multiple kilobytes in size,
+     * a blocking socket may be required if the receipt buffer of the broker is not large enough.
      *
-     * Note: When using a blocking socket, the MQTT client can get stuck if the socket is broken
-     *       or when the broker does not consume the sent data fast enough. Use with caution.
+     * Note: This setting has no effect on subscriptions, only on the publishing of messages.
      *
      * @param bool $useBlockingSocket
      * @return ConnectionSettings
@@ -97,7 +95,7 @@ class ConnectionSettings
     {
         $copy = clone $this;
 
-        $copy->useBlockingModeForSocket = $useBlockingSocket;
+        $copy->useBlockingSocket = $useBlockingSocket;
 
         return $copy;
     }

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -290,7 +290,7 @@ class MqttClient implements ClientContract
         }
 
         stream_set_timeout($socket, $this->settings->getSocketTimeout());
-        stream_set_blocking($socket, $this->settings->shouldUseBlockingSocket());
+        stream_set_blocking($socket, false);
 
         $this->logger->debug('Socket opened and ready to use.');
 
@@ -1140,7 +1140,15 @@ class MqttClient implements ClientContract
         $calculatedLength = strlen($data);
         $length           = min($length ?? $calculatedLength, $calculatedLength);
 
+        if ($this->settings->shouldUseBlockingSocket()) {
+            socket_set_blocking($this->socket, true);
+        }
+
         $result = @fwrite($this->socket, $data, $length);
+
+        if ($this->settings->shouldUseBlockingSocket()) {
+            socket_set_blocking($this->socket, false);
+        }
 
         if ($result === false || $result !== $length) {
             $this->logger->error('Sending data over the socket to the broker failed.');


### PR DESCRIPTION
This PR replaces #139 and fixes the implementation of #135.

**Issue:**
Currently, the connection setting added in #135 has no effect due to a typo in the assignment.

**Background:**
Due to the nature of MQTT and how network communication works, non-blocking mode for sockets is quite essential when reading data received from the MQTT broker. If such reads are performed in blocking mode and no data is received from the broker over a long period of time, the connection may timeout.

**Solution:**
This PR fixes the typo in the connection settings. Because this fix introduces an issue when blocking mode is used for the socket, the meaning of the setting has been changed slightly. It now only affects the publishing of messages and is not used for reads on the socket.