### PR TITLE
Add connected event (handler)

### DIFF
--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -6,8 +6,8 @@ namespace PhpMqtt\Client;
 
 /**
  * The settings used during connection to a broker.
- * 
- * This class is immutable and all setters return a clone of the original class because 
+ *
+ * This class is immutable and all setters return a clone of the original class because
  * connection settings must not change once passed to MqttClient.
  *
  * @package PhpMqtt\Client

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -6,8 +6,8 @@ namespace PhpMqtt\Client;
 
 /**
  * The settings used during connection to a broker.
- *
- * This class is immutable and all setters return a clone of the original class because
+ * 
+ * This class is immutable and all setters return a clone of the original class because 
  * connection settings must not change once passed to MqttClient.
  *
  * @package PhpMqtt\Client

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -148,10 +148,11 @@ class MqttClient implements ClientContract
      * Connect to the MQTT broker using the configured settings.
      *
      * @param bool $useCleanSession
+     * @param bool $isAutoReconnect
      * @return void
      * @throws ConnectingToBrokerFailedException
      */
-    protected function connectInternal(bool $useCleanSession = false): void
+    protected function connectInternal(bool $useCleanSession = false, bool $isAutoReconnect = false): void
     {
         try {
             $this->establishSocketConnection();
@@ -163,7 +164,8 @@ class MqttClient implements ClientContract
         }
 
         $this->connected = true;
-        $this->runConnectedEventHandlers();
+
+        $this->runConnectedEventHandlers($isAutoReconnect);
     }
 
     /**
@@ -415,7 +417,7 @@ class MqttClient implements ClientContract
 
         for ($i = 1; $i <= $maxReconnectAttempts; $i++) {
             try {
-                $this->connectInternal();
+                $this->connectInternal(false, true);
 
                 return;
             } catch (ConnectingToBrokerFailedException $e) {

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -163,6 +163,7 @@ class MqttClient implements ClientContract
         }
 
         $this->connected = true;
+        $this->runConnectedEventHandlers();
     }
 
     /**

--- a/src/Repositories/MemoryRepository.php
+++ b/src/Repositories/MemoryRepository.php
@@ -191,11 +191,8 @@ class MemoryRepository implements Repository
      */
     public function addSubscription(Subscription $subscription): void
     {
-        foreach ($this->subscriptions as $registeredSubscription) {
-            if ($subscription->getTopicFilter() === $registeredSubscription->getTopicFilter()) {
-                return;
-            }
-        }
+        // Remove a potentially existing subscription for this topic filter.
+        $this->removeSubscription($subscription->getTopicFilter());
 
         $this->subscriptions[] = $subscription;
     }
@@ -223,16 +220,13 @@ class MemoryRepository implements Repository
      */
     public function removeSubscription(string $topicFilter): bool
     {
-        $result = false;
-
         foreach ($this->subscriptions as $index => $subscription) {
             if ($subscription->getTopicFilter() === $topicFilter) {
                 unset($this->subscriptions[$index]);
-                $result = true;
-                break;
+                return true;
             }
         }
 
-        return $result;
+        return false;
     }
 }

--- a/src/Repositories/MemoryRepository.php
+++ b/src/Repositories/MemoryRepository.php
@@ -191,6 +191,12 @@ class MemoryRepository implements Repository
      */
     public function addSubscription(Subscription $subscription): void
     {
+        foreach ($this->subscriptions as $registeredSubscription) {
+            if ($subscription->getTopicFilter() === $registeredSubscription->getTopicFilter()) {
+                return;
+            }
+        }
+
         $this->subscriptions[] = $subscription;
     }
 

--- a/tests/Feature/ConnectedEventHandlerTest.php
+++ b/tests/Feature/ConnectedEventHandlerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use PhpMqtt\Client\MqttClient;
+use Tests\TestCase;
+
+/**
+ * Tests that the connected event handler work as intended.
+ *
+ * @package Tests\Feature
+ */
+class ConnectedEventHandlerTest extends TestCase
+{
+    public function test_connected_event_handlers_are_called_every_time_the_client_connects_successfully(): void
+    {
+        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-connected-event-handler');
+
+        $handlerCallCount = 0;
+        $handler = function () use (&$handlerCallCount) {
+            $handlerCallCount++;
+        };
+
+        $client->registerConnectedEventHandler($handler);
+        $client->connect();
+
+        $this->assertSame(1, $handlerCallCount);
+
+        $client->disconnect();
+        $client->connect();
+
+        $this->assertSame(2, $handlerCallCount);
+
+        $client->disconnect();
+        $client->connect();
+
+        $this->assertSame(3, $handlerCallCount);
+
+        $client->disconnect();
+    }
+
+    public function test_connected_event_handlers_can_be_unregistered_and_will_not_be_called_anymore(): void
+    {
+        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-connected-event-handler');
+
+        $handlerCallCount = 0;
+        $handler = function () use (&$handlerCallCount) {
+            $handlerCallCount++;
+        };
+
+        $client->registerConnectedEventHandler($handler);
+        $client->connect();
+
+        $this->assertSame(1, $handlerCallCount);
+
+        $client->unregisterConnectedEventHandler($handler);
+        $client->disconnect();
+        $client->connect();
+
+        $this->assertSame(1, $handlerCallCount);
+
+        $client->registerConnectedEventHandler($handler);
+        $client->disconnect();
+        $client->connect();
+
+        $this->assertSame(2, $handlerCallCount);
+
+        $client->unregisterConnectedEventHandler($handler);
+        $client->disconnect();
+        $client->connect();
+
+        $this->assertSame(2, $handlerCallCount);
+
+        $client->disconnect();
+    }
+
+    public function test_connected_event_handlers_can_throw_exceptions_which_does_not_affect_other_handlers_or_the_application(): void
+    {
+        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-connected-event-handler');
+
+        $handlerCallCount = 0;
+        $handler1 = function () use (&$handlerCallCount) {
+            $handlerCallCount++;
+        };
+        $handler2 = function () {
+            throw new \Exception('Something went wrong!');
+        };
+
+        $client->registerConnectedEventHandler($handler1);
+        $client->registerConnectedEventHandler($handler2);
+
+        $client->connect();
+
+        $this->assertSame(1, $handlerCallCount);
+
+        $client->disconnect();
+    }
+
+    public function test_connected_event_handler_is_passed_the_mqtt_client_and_the_auto_reconnect_flag_as_arguments(): void
+    {
+        $client = new MqttClient($this->mqttBrokerHost, $this->mqttBrokerPort, 'test-connected-event-handler');
+
+        $client->registerConnectedEventHandler(function ($mqttClient, $isAutoReconnect) {
+            $this->assertInstanceOf(MqttClient::class, $mqttClient);
+            $this->assertIsBool($isAutoReconnect);
+            $this->assertFalse($isAutoReconnect);
+        });
+
+        $client->connect();
+        $client->disconnect();
+    }
+}

--- a/tests/Feature/PublishEventHandlerTest.php
+++ b/tests/Feature/PublishEventHandlerTest.php
@@ -10,7 +10,7 @@ use PhpMqtt\Client\MqttClient;
 use Tests\TestCase;
 
 /**
- * Tests that the loop event handler work as intended.
+ * Tests that the publish event handler work as intended.
  *
  * @package Tests\Feature
  */


### PR DESCRIPTION
This PR will add a new event handler list for an "connected"-event (ref #143).
I also had to add an duplicate check for the subscriptions, to prevent duplicated execution of the subscriptions callbacks.
I'm not sure if this should be the goal, maybe it could make more sense to add option for it or maybe clear the subscriptions if the connection is lost.

@Namoshek Do you have an idea for the duplicated subscription issue ?
