### PR TITLE
Fix: Allow isPublishMessageWithNullCharacter to receive messages as null

### DIFF
--- a/src/MessageProcessors/Mqtt311MessageProcessor.php
+++ b/src/MessageProcessors/Mqtt311MessageProcessor.php
@@ -66,10 +66,10 @@ class Mqtt311MessageProcessor extends Mqtt31MessageProcessor
     /**
      * Determines if the given message is a PUBLISH message and contains the unicode null character U+0000.
      *
-     * @param Message $message
+     * @param Message|null $message
      * @return bool
      */
-    private function isPublishMessageWithNullCharacter(Message $message): bool
+    private function isPublishMessageWithNullCharacter(?Message $message): bool
     {
         return $message !== null
             && $message->getType()->equals(MessageType::PUBLISH())


### PR DESCRIPTION
In `src/MessageProcessors/Mqtt311MessageProcessor.php`

`parseAndValidateMessage` can return null values however `isPublishMessageWithNullCharacter` expects type to be `Message`.

This change aims to address `isPublishMessageWithNullCharacter` being able to also process null messages.