### PR TITLE
QoS 1 should only acknowledge if the handlers did not throw an Exception

### DIFF
--- a/src/Concerns/OffersHooks.php
+++ b/src/Concerns/OffersHooks.php
@@ -255,20 +255,23 @@ trait OffersHooks
      * @param string $message
      * @param int    $qualityOfService
      * @param bool   $retained
-     * @return void
+     * @return bool False if an Event Handler threw an Exception, True otherwise.
      */
-    private function runMessageReceivedEventHandlers(string $topic, string $message, int $qualityOfService, bool $retained): void
+    private function runMessageReceivedEventHandlers(string $topic, string $message, int $qualityOfService, bool $retained): bool
     {
+        $one_callback_failed = false;
         foreach ($this->messageReceivedEventHandlers as $handler) {
             try {
                 call_user_func($handler, $this, $topic, $message, $qualityOfService, $retained);
             } catch (\Throwable $e) {
+                $one_callback_failed = true;
                 $this->logger->error('Received message hook callback threw exception for received message on topic [{topic}].', [
                     'topic' => $topic,
                     'exception' => $e,
                 ]);
             }
         }
+        return !$one_callback_failed;
     }
 
     /**


### PR DESCRIPTION
Today I noticed a problem where messages have been "lost", and it turns out that in the QoS 1 message-received-handler, there was an Exception. PHP-MQTT-Client has acknowledged the QoS 1 message although my code failed to process it.

This patch fixes the problem: When the message-received-handler fails with an Exception, then the message will not be acknowledged.

I am not 100% sure if I should also handle the case "Subscriber callback threw exception for published message". I have included this case since I think the message should only be acknowledged if the whole code/callbacks/handlers are processed smoothly without any errors.

What do you think?