### PR TITLE
Implement delivery of retain flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,13 +27,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java 11 (for keytool)
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '11'
-          java-package: 'jre'
-
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
@@ -140,7 +133,7 @@ jobs:
           sed -i "s|$GITHUB_WORKSPACE|/github/workspace|g" phpunit.report-junit.xml
 
       - name: Run SonarQube analysis
-        uses: sonarsource/sonarcloud-github-action@v1.9
+        uses: sonarsource/sonarcloud-github-action@v2.0.2
         if: matrix.run-sonarqube-analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/Message.php
+++ b/src/Message.php
@@ -18,6 +18,7 @@ class Message
 {
     private MessageType $type;
     private int $qualityOfService;
+    private bool $retained;
     private ?int $messageId  = null;
     private ?string $topic   = null;
     private ?string $content = null;
@@ -30,11 +31,13 @@ class Message
      *
      * @param MessageType $type
      * @param int         $qualityOfService
+     * @param bool        $retained
      */
-    public function __construct(MessageType $type, int $qualityOfService = 0)
+    public function __construct(MessageType $type, int $qualityOfService = 0, bool $retained = false)
     {
         $this->type             = $type;
         $this->qualityOfService = $qualityOfService;
+        $this->retained         = $retained;
     }
 
     /**
@@ -51,6 +54,14 @@ class Message
     public function getQualityOfService(): int
     {
         return $this->qualityOfService;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getRetained(): bool
+    {
+        return $this->retained;
     }
 
     /**

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -757,7 +757,7 @@ class MqttClient implements ClientContract
                         $message->getTopic(),
                         $message->getContent(),
                         2,
-                        false
+                        $message->getRetained()
                     );
                     $this->repository->addPendingIncomingMessage($pendingMessage);
                 } catch (PendingMessageAlreadyExistsException $e) {
@@ -772,7 +772,7 @@ class MqttClient implements ClientContract
             }
 
             // For QoS 0 and QoS 1 we can deliver right away.
-            $this->deliverPublishedMessage($message->getTopic(), $message->getContent(), $message->getQualityOfService());
+            $this->deliverPublishedMessage($message->getTopic(), $message->getContent(), $message->getQualityOfService(), $message->getRetained());
             return;
         }
 
@@ -821,7 +821,8 @@ class MqttClient implements ClientContract
                 $this->deliverPublishedMessage(
                     $pendingMessage->getTopicName(),
                     $pendingMessage->getMessage(),
-                    $pendingMessage->getQualityOfServiceLevel()
+                    $pendingMessage->getQualityOfServiceLevel(),
+                    $pendingMessage->wantsToBeRetained()
                 );
 
                 $this->repository->removePendingIncomingMessage($message->getMessageId());

--- a/tests/Feature/PublishSubscribeTest.php
+++ b/tests/Feature/PublishSubscribeTest.php
@@ -20,22 +20,32 @@ class PublishSubscribeTest extends TestCase
 {
     public function publishSubscribeData(): array
     {
-        return [
-            [false, 'test/foo/bar/baz', 'test/foo/bar/baz', 'hello world', []],
-            [false, 'test/foo/bar/+', 'test/foo/bar/baz', 'hello world', ['baz']],
-            [false, 'test/foo/+/baz', 'test/foo/bar/baz', 'hello world', ['bar']],
-            [false, 'test/foo/#', 'test/foo/bar/baz', 'hello world', ['bar/baz']],
-            [false, 'test/foo/+/bar/#', 'test/foo/my/bar/baz', 'hello world', ['my', 'baz']],
-            [false, 'test/foo/+/bar/#', 'test/foo/my/bar/baz/blub', 'hello world', ['my', 'baz/blub']],
-            [false, 'test/foo/bar/baz', 'test/foo/bar/baz', random_bytes(2 * 1024 * 1024), []], // 2MB message
-            [true, 'test/foo/bar/baz', 'test/foo/bar/baz', 'hello world', []],
-            [true, 'test/foo/bar/+', 'test/foo/bar/baz', 'hello world', ['baz']],
-            [true, 'test/foo/+/baz', 'test/foo/bar/baz', 'hello world', ['bar']],
-            [true, 'test/foo/#', 'test/foo/bar/baz', 'hello world', ['bar/baz']],
-            [true, 'test/foo/+/bar/#', 'test/foo/my/bar/baz', 'hello world', ['my', 'baz']],
-            [true, 'test/foo/+/bar/#', 'test/foo/my/bar/baz/blub', 'hello world', ['my', 'baz/blub']],
-            [true, 'test/foo/bar/baz', 'test/foo/bar/baz', random_bytes(2 * 1024 * 1024), []], // 2MB message
+        $data = [
+            [false, 'foo/bar/baz', 'foo/bar/baz', 'hello world', []],
+            [false, 'foo/bar/+', 'foo/bar/baz', 'hello world', ['baz']],
+            [false, 'foo/+/baz', 'foo/bar/baz', 'hello world', ['bar']],
+            [false, 'foo/#', 'foo/bar/baz', 'hello world', ['bar/baz']],
+            [false, 'foo/+/bar/#', 'foo/my/bar/baz', 'hello world', ['my', 'baz']],
+            [false, 'foo/+/bar/#', 'foo/my/bar/baz/blub', 'hello world', ['my', 'baz/blub']],
+            [false, 'foo/bar/baz', 'foo/bar/baz', random_bytes(2 * 1024 * 1024), []], // 2MB message
+            [true, 'foo/bar/baz', 'foo/bar/baz', 'hello world', []],
+            [true, 'foo/bar/+', 'foo/bar/baz', 'hello world', ['baz']],
+            [true, 'foo/+/baz', 'foo/bar/baz', 'hello world', ['bar']],
+            [true, 'foo/#', 'foo/bar/baz', 'hello world', ['bar/baz']],
+            [true, 'foo/+/bar/#', 'foo/my/bar/baz', 'hello world', ['my', 'baz']],
+            [true, 'foo/+/bar/#', 'foo/my/bar/baz/blub', 'hello world', ['my', 'baz/blub']],
+            [true, 'foo/bar/baz', 'foo/bar/baz', random_bytes(2 * 1024 * 1024), []], // 2MB message
         ];
+
+        // Because our tests are run against a real MQTT broker and some messages are retained,
+        // we need to prevent false-positives by giving each test case its own 'test space' using a random prefix.
+        for ($i = 0; $i < count($data); $i++) {
+            $prefix = 'test/' . uniqid('', true) . '/';
+            $data[$i][1] = $prefix . $data[$i][1];
+            $data[$i][2] = $prefix . $data[$i][2];
+        }
+
+        return $data;
     }
 
     /**
@@ -102,6 +112,10 @@ class PublishSubscribeTest extends TestCase
         $publisher->publish($publishTopic, $publishMessage, 0, true);
 
         $publisher->disconnect();
+
+        // Because we need to make sure the message reached the broker, we delay the execution for a short period (100ms) intentionally.
+        // With higher QoS, this is replaced by awaiting delivery of the message.
+        usleep(100_000);
 
         // We connect and subscribe to a topic using the second client.
         $connectionSettings = (new ConnectionSettings())
@@ -193,6 +207,7 @@ class PublishSubscribeTest extends TestCase
         $publisher->connect(null, true);
 
         $publisher->publish($publishTopic, $publishMessage, 1, true);
+        $publisher->loop(true, true);
 
         $publisher->disconnect();
 


### PR DESCRIPTION
This PR adds the `retain` flag provided by MQTT brokers to delivered messages. For some reason, this was never implemented.

Details:
- The addition requires breaking a few of the internal APIs, hence this PR forces a major version bump at release.
- Because the tests for the retained flag will leak the published messages to other tests, some randomization was added for the topics used by these test cases.