### PR TITLE
Added support for TLS ALPN to connect via MQTT protocol to a TLS encrypted HTTP port 443

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ $connectionSettings = (new \PhpMqtt\Client\ConnectionSettings)
     // This option requires ConnectionSettings::setTlsClientCertificateFile() and
     // ConnectionSettings::setTlsClientCertificateKeyFile() to be used as well.
     ->setTlsClientCertificateKeyPassphrase(null);
+
+     // The TLS ALPN is used to establish a TLS encrypted mqtt connection on port 443,
+     // which usually is reserved for TLS encrypted HTTP traffic.
+     ->setTlsAlpn(null);
 ```
 
 ## Features

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -37,6 +37,7 @@ class ConnectionSettings
     private ?string $tlsClientCertificateFile          = null;
     private ?string $tlsClientCertificateKeyFile       = null;
     private ?string $tlsClientCertificateKeyPassphrase = null;
+    private ?string $tlsAlpn                           = null;
 
     /**
      * The username used for authentication when connecting to the broker.
@@ -531,4 +532,25 @@ class ConnectionSettings
     {
         return $this->tlsClientCertificateKeyPassphrase;
     }
+
+    /**
+     * The TLS ALPN is used to establish a TLS encrypted mqtt connection on port 443,
+     * which usually is reserved for TLS encrypted HTTP traffic.
+     *
+     * @return ConnectionSettings A copy of the original object with the new setting applied.
+     */
+    public function setTlsAlpn(?string $tlsAlpn): ConnectionSettings
+    {
+        $copy = clone $this;
+
+        $copy->tlsAlpn = $tlsAlpn;
+
+        return $copy;
+    }
+
+    public function getTlsAlpn(): ?string
+    {
+        return $this->tlsAlpn;
+    }
+
 }

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -197,6 +197,9 @@ class MqttClient implements ClientContract
                 $tlsOptions['passphrase'] = $this->settings->getTlsClientCertificateKeyPassphrase();
             }
 
+            if ($this->settings->getTlsAlpn() !== null) {
+                $tlsOptions['alpn_protocols'] = $this->settings->getTlsAlpn();
+ 
             $contextOptions['ssl'] = $tlsOptions;
         }
 

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -199,6 +199,7 @@ class MqttClient implements ClientContract
 
             if ($this->settings->getTlsAlpn() !== null) {
                 $tlsOptions['alpn_protocols'] = $this->settings->getTlsAlpn();
+            }
  
             $contextOptions['ssl'] = $tlsOptions;
         }


### PR DESCRIPTION
Added support for TLS ALPN to connect via MQTT protocol to a TLS encrypted HTTP port 443

With

->setTlsAlpn('mqtt')

it is now possible to use MQTT protocol on a TLS encrypted hTTP port 443 (server side has to support this).