### PR TITLE
Fix: PHP 8.4 - Implicitly nullable parameter declarations deprecated

### DIFF
--- a/src/Concerns/OffersHooks.php
+++ b/src/Concerns/OffersHooks.php
@@ -73,7 +73,7 @@ trait OffersHooks
      * This does not affect other registered event handlers. It is possible
      * to unregister all registered event handlers by passing null as callback.
      */
-    public function unregisterLoopEventHandler(\Closure $callback = null): MqttClient
+    public function unregisterLoopEventHandler(?\Closure $callback = null): MqttClient
     {
         if ($callback === null) {
             $this->loopEventHandlers->removeAll($this->loopEventHandlers);
@@ -139,7 +139,7 @@ trait OffersHooks
      * This does not affect other registered event handlers. It is possible
      * to unregister all registered event handlers by passing null as callback.
      */
-    public function unregisterPublishEventHandler(\Closure $callback = null): MqttClient
+    public function unregisterPublishEventHandler(?\Closure $callback = null): MqttClient
     {
         if ($callback === null) {
             $this->publishEventHandlers->removeAll($this->publishEventHandlers);
@@ -205,7 +205,7 @@ trait OffersHooks
      * This does not affect other registered event handlers. It is possible
      * to unregister all registered event handlers by passing null as callback.
      */
-    public function unregisterMessageReceivedEventHandler(\Closure $callback = null): MqttClient
+    public function unregisterMessageReceivedEventHandler(?\Closure $callback = null): MqttClient
     {
         if ($callback === null) {
             $this->messageReceivedEventHandlers->removeAll($this->messageReceivedEventHandlers);
@@ -272,7 +272,7 @@ trait OffersHooks
      * This does not affect other registered event handlers. It is possible
      * to unregister all registered event handlers by passing null as callback.
      */
-    public function unregisterConnectedEventHandler(\Closure $callback = null): MqttClient
+    public function unregisterConnectedEventHandler(?\Closure $callback = null): MqttClient
     {
         if ($callback === null) {
             $this->connectedEventHandlers->removeAll($this->connectedEventHandlers);

--- a/src/Contracts/MqttClient.php
+++ b/src/Contracts/MqttClient.php
@@ -28,7 +28,7 @@ interface MqttClient
      * @throws ConfigurationInvalidException
      * @throws ConnectingToBrokerFailedException
      */
-    public function connect(ConnectionSettings $settings = null, bool $useCleanSession = false): void;
+    public function connect(?ConnectionSettings $settings = null, bool $useCleanSession = false): void;
 
     /**
      * Sends a disconnect message to the broker and closes the socket.
@@ -195,7 +195,7 @@ interface MqttClient
      * This does not affect other registered event handlers. It is possible
      * to unregister all registered event handlers by passing null as callback.
      */
-    public function unregisterLoopEventHandler(\Closure $callback = null): MqttClient;
+    public function unregisterLoopEventHandler(?\Closure $callback = null): MqttClient;
 
     /**
      * Registers a loop event handler which is called when a message is published.
@@ -230,7 +230,7 @@ interface MqttClient
      * This does not affect other registered event handlers. It is possible
      * to unregister all registered event handlers by passing null as callback.
      */
-    public function unregisterPublishEventHandler(\Closure $callback = null): MqttClient;
+    public function unregisterPublishEventHandler(?\Closure $callback = null): MqttClient;
 
     /**
      * Registers an event handler which is called when a message is received from the broker.
@@ -262,5 +262,5 @@ interface MqttClient
      * This does not affect other registered event handlers. It is possible
      * to unregister all registered event handlers by passing null as callback.
      */
-    public function unregisterMessageReceivedEventHandler(\Closure $callback = null): MqttClient;
+    public function unregisterMessageReceivedEventHandler(?\Closure $callback = null): MqttClient;
 }

--- a/src/Contracts/Repository.php
+++ b/src/Contracts/Repository.php
@@ -61,7 +61,7 @@ interface Repository
      *
      * @return PendingMessage[]
      */
-    public function getPendingOutgoingMessagesLastSentBefore(DateTime $dateTime = null): array;
+    public function getPendingOutgoingMessagesLastSentBefore(?DateTime $dateTime = null): array;
 
     /**
      * Adds a pending outgoing message to the repository.

--- a/src/Exceptions/MqttClientException.php
+++ b/src/Exceptions/MqttClientException.php
@@ -14,7 +14,7 @@ class MqttClientException extends \Exception
     /**
      * MqttClientException constructor.
      */
-    public function __construct(string $message = '', int $code = 0, \Throwable $parentException = null)
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $parentException = null)
     {
         if (empty($message)) {
             parent::__construct(

--- a/src/MessageProcessors/Mqtt31MessageProcessor.php
+++ b/src/MessageProcessors/Mqtt31MessageProcessor.php
@@ -31,7 +31,7 @@ class Mqtt31MessageProcessor extends BaseMessageProcessor implements MessageProc
     /**
      * {@inheritDoc}
      */
-    public function tryFindMessageInBuffer(string $buffer, int $bufferLength, string &$message = null, int &$requiredBytes = -1): bool
+    public function tryFindMessageInBuffer(string $buffer, int $bufferLength, ?string &$message = null, int &$requiredBytes = -1): bool
     {
         // If we received no input, we can return immediately without doing work.
         if ($bufferLength === 0) {
@@ -328,7 +328,7 @@ class Mqtt31MessageProcessor extends BaseMessageProcessor implements MessageProc
         string $message,
         int $qualityOfService,
         bool $retain,
-        int $messageId = null,
+        ?int $messageId = null,
         bool $isDuplicate = false,
     ): string
     {

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -75,8 +75,8 @@ class MqttClient implements ClientContract
         private int $port = 1883,
         ?string $clientId = null,
         string $protocol = self::MQTT_3_1,
-        Repository $repository = null,
-        LoggerInterface $logger = null
+        ?Repository $repository = null,
+        ?LoggerInterface $logger = null
     )
     {
         if (!in_array($protocol, [self::MQTT_3_1, self::MQTT_3_1_1])) {
@@ -97,7 +97,7 @@ class MqttClient implements ClientContract
     /**
      * {@inheritDoc}
      */
-    public function connect(ConnectionSettings $settings = null, bool $useCleanSession = false): void
+    public function connect(?ConnectionSettings $settings = null, bool $useCleanSession = false): void
     {
         // Always abruptly close any previous connection if we are opening a new one.
         // The caller should make sure this does not happen.
@@ -546,7 +546,7 @@ class MqttClient implements ClientContract
     /**
      * {@inheritDoc}
      */
-    public function subscribe(string $topicFilter, callable $callback = null, int $qualityOfService = self::QOS_AT_MOST_ONCE): void
+    public function subscribe(string $topicFilter, ?callable $callback = null, int $qualityOfService = self::QOS_AT_MOST_ONCE): void
     {
         $this->ensureConnected();
 
@@ -598,7 +598,7 @@ class MqttClient implements ClientContract
     /**
      * {@inheritDoc}
      */
-    public function loop(bool $allowSleep = true, bool $exitWhenQueuesEmpty = false, int $queueWaitLimit = null): void
+    public function loop(bool $allowSleep = true, bool $exitWhenQueuesEmpty = false, ?int $queueWaitLimit = null): void
     {
         $this->logger->debug('Starting client loop to process incoming messages and the resend queue.');
 

--- a/src/PendingMessage.php
+++ b/src/PendingMessage.php
@@ -25,7 +25,7 @@ abstract class PendingMessage
     /**
      * Creates a new pending message object.
      */
-    protected function __construct(private int $messageId, DateTime $sentAt = null)
+    protected function __construct(private int $messageId, ?DateTime $sentAt = null)
     {
         $this->lastSentAt = $sentAt ?? new DateTime();
     }
@@ -57,7 +57,7 @@ abstract class PendingMessage
     /**
      * Sets the date time when the message was last sent.
      */
-    public function setLastSentAt(DateTime $value = null): self
+    public function setLastSentAt(?DateTime $value = null): self
     {
         $this->lastSentAt = $value ?? new DateTime();
 

--- a/src/Repositories/MemoryRepository.php
+++ b/src/Repositories/MemoryRepository.php
@@ -86,7 +86,7 @@ class MemoryRepository implements Repository
     /**
      * {@inheritDoc}
      */
-    public function getPendingOutgoingMessagesLastSentBefore(\DateTime $dateTime = null): array
+    public function getPendingOutgoingMessagesLastSentBefore(?\DateTime $dateTime = null): array
     {
         $result = [];
 


### PR DESCRIPTION
This PR fixes #191 to fix implicitly nullable parameter declarations in PHP 8.4. 