### PR TITLE
Test against PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
         mqtt-broker: ['mosquitto-1.6', 'mosquitto-2.0', 'hivemq', 'emqx', 'rabbitmq']
         include:
-          - php-version: '8.3'
+          - php-version: '8.4'
             mqtt-broker: 'mosquitto-2.0'
             run-sonarqube-analysis: true
 


### PR DESCRIPTION
This PR adds PHP 8.4 to the test pipeline (and removes the EOL version 8.0 of PHP).