### PR TITLE
Add ping response timeout handling

### DIFF
--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -45,9 +45,10 @@ class MqttClient implements ClientContract
     public const SOCKET_READ_BUFFER_SIZE = 8192;
     private string $clientId;
     private ConnectionSettings $settings;
-    private string $buffer     = '';
-    private bool $connected    = false;
-    private ?float $lastPingAt = null;
+    private string $buffer                    = '';
+    private bool $connected                   = false;
+    private ?float $lastPingAt                = null;
+    private ?float $pingResponseExpectedUntil = null;
     private MessageProcessor $messageProcessor;
     private Repository $repository;
     private LoggerInterface $logger;
@@ -489,6 +490,7 @@ class MqttClient implements ClientContract
             stream_socket_shutdown($this->socket, STREAM_SHUT_WR);
         }
 
+        $this->socket    = null;
         $this->connected = false;
     }
 
@@ -649,6 +651,28 @@ class MqttClient implements ClientContract
         // Republish messages expired without confirmation.
         // This includes published messages, subscribe and unsubscribe requests.
         $this->resendPendingMessages();
+
+        // If the last ping we sent has not been answered within the configured keep alive interval,
+        // we assume the connection is dead and try to reconnect if configured to do so.
+        if ($this->pingResponseExpectedUntil !== null && microtime(true) > $this->pingResponseExpectedUntil) {
+            $this->logger->warning(
+                'The broker did not respond to our ping request within the configured keep alive interval. Assuming the connection is dead.'
+            );
+
+            $this->closeSocket();
+
+            $this->lastPingAt                = null;
+            $this->pingResponseExpectedUntil = null;
+
+            if (!$this->settings->shouldReconnectAutomatically()) {
+                throw new DataTransferException(
+                    DataTransferException::EXCEPTION_RX_DATA,
+                    'No ping response received in time. The connection is dead.'
+                );
+            }
+
+            $this->reconnect();
+        }
 
         // If the last message of the broker has been received more seconds ago
         // than specified by the keep alive time, we will send a ping to ensure
@@ -869,6 +893,14 @@ class MqttClient implements ClientContract
             $this->writeToSocketWithAutoReconnect($this->messageProcessor->buildPingResponseMessage());
             return;
         }
+
+        // PINGRESP
+        if ($message->getType()->equals(MessageType::PING_RESPONSE())) {
+            // Set the ping response expectation to null, so we know the broker responded.
+            $this->logger->debug('Received ping response from the broker.');
+            $this->pingResponseExpectedUntil = null;
+            return;
+        }
     }
 
     /**
@@ -1020,6 +1052,8 @@ class MqttClient implements ClientContract
         $this->logger->debug('Sending ping to the broker to keep the connection alive.');
 
         $this->writeToSocketWithAutoReconnect($this->messageProcessor->buildPingRequestMessage());
+
+        $this->pingResponseExpectedUntil = microtime(true) + $this->settings->getKeepAliveInterval();
     }
 
     /**
@@ -1231,6 +1265,7 @@ class MqttClient implements ClientContract
             ]);
         }
 
-        $this->socket = null;
+        $this->socket    = null;
+        $this->connected = false;
     }
 }


### PR DESCRIPTION
This pull request enhances the MQTT client's connection reliability by introducing logic to detect and handle situations where the broker does not respond to ping requests within the configured keep alive interval. The changes ensure the client can automatically reconnect or throw an exception if the connection is deemed dead, improving fault tolerance and connection management.

**Connection reliability improvements:**

* Added a new property `pingResponseExpectedUntil` to track the deadline for receiving a ping response from the broker.
* In the main loop (`loopOnce`), implemented logic to check if a ping response was received in time. If not, the client logs a warning, closes the socket, resets ping tracking, and either reconnects automatically or throws a `DataTransferException` depending on settings.
* Updated the `ping()` method to set `pingResponseExpectedUntil` whenever a ping request is sent, establishing a deadline for the broker's response. The expected deadline depends on the keep alive interval [as specified in the MQTT documentation](https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#keep-alive-timer):

  > If a client does not receive a [PINGRESP](https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#pingresp) message within a Keep Alive time period after sending a [PINGREQ](https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#pingreq), it should close the TCP/IP socket connection.
* Modified `handleMessage()` to clear `pingResponseExpectedUntil` when a ping response (`PINGRESP`) is received, confirming the broker's responsiveness.

**Socket and connection state management:**

* Ensured that both `disconnect()` and `closeSocket()` methods set `$this->socket` to `null` and `$this->connected` to `false` for consistent connection state tracking. [[1]](diffhunk://#diff-39d3bd06e991ef82d0b3b64a9a342bf023b2e505ba006031631e77c3a58d8379R493) [[2]](diffhunk://#diff-39d3bd06e991ef82d0b3b64a9a342bf023b2e505ba006031631e77c3a58d8379R1269)